### PR TITLE
Gate cache_prompt to llama.cpp backends only

### DIFF
--- a/zarlai/service/llamacpp.go
+++ b/zarlai/service/llamacpp.go
@@ -78,6 +78,7 @@ func NewLlamaCppClient(baseURL, model string, embedder Embedder, opts ...LlamaCp
 	popts := []options.Option[openai.Provider]{
 		openai.WithBaseURL(baseURL),
 		openai.WithModel(model),
+		openai.WithCachePrompt(true),
 	}
 	if lc.httpClient != nil {
 		popts = append(popts, openai.WithHTTPClient(lc.httpClient))

--- a/zkit/ai/llm/backends/adapter.go
+++ b/zkit/ai/llm/backends/adapter.go
@@ -14,6 +14,11 @@ type buildParams struct {
 	model            string
 	reasoningHistory llm.ReasoningHistory
 	options          llm.ModelOptions
+	// cachePrompt requests the llama.cpp-only `cache_prompt` extension on
+	// the built provider. Set only for the llama.cpp built-in; strict
+	// OpenAI-compatible backends and forwarding proxies (LiteLLM) reject
+	// the unknown field with HTTP 400.
+	cachePrompt bool
 }
 
 // adapterDef bundles the constructor for one adapter type.

--- a/zkit/ai/llm/backends/definitions.go
+++ b/zkit/ai/llm/backends/definitions.go
@@ -279,6 +279,9 @@ func init() {
 			if p.model != "" {
 				opts = append(opts, openai.WithModel(p.model))
 			}
+			if p.cachePrompt {
+				opts = append(opts, openai.WithCachePrompt(true))
+			}
 			return openai.NewProvider(p.apiKey, opts...)
 		},
 		noKeyOK: false,

--- a/zkit/ai/llm/backends/registry.go
+++ b/zkit/ai/llm/backends/registry.go
@@ -221,6 +221,11 @@ func (r *ProviderRegistry) BuildWithConfig(ctx context.Context, name string, cfg
 		baseURL:          cfg.BaseURL,
 		model:            cfg.Model,
 		reasoningHistory: def.ReasoningHistory,
+		// cache_prompt is a llama.cpp server extension. Enable it only for
+		// the llama.cpp built-in — hosted OpenAI, Ollama, and custom
+		// DB-backed providers (e.g. a LiteLLM proxy) reject the unknown
+		// field with HTTP 400.
+		cachePrompt: def.Builtin && def.Name == DefaultBuiltinName.String(),
 	}
 
 	// Route through the adapter layer.

--- a/zkit/ai/llm/llamacpp/llamacpp.go
+++ b/zkit/ai/llm/llamacpp/llamacpp.go
@@ -56,6 +56,7 @@ func NewProvider(opts ...options.Option[Provider]) (llm.Provider, error) {
 
 	innerOpts := []options.Option[openai.Provider]{
 		openai.WithBaseURL(p.baseURL),
+		openai.WithCachePrompt(true),
 	}
 	if p.timeout > 0 {
 		innerOpts = append(innerOpts, openai.WithTimeout(p.timeout))

--- a/zkit/ai/llm/openai/cache_prompt_test.go
+++ b/zkit/ai/llm/openai/cache_prompt_test.go
@@ -1,0 +1,77 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zkit/ai/llm"
+	"github.com/zarldev/zarlmono/zkit/ai/llm/openai"
+	"github.com/zarldev/zarlmono/zkit/options"
+)
+
+// TestRequest_CachePromptGating checks that the non-standard llama.cpp
+// `cache_prompt` field is sent only when the provider was built with
+// WithCachePrompt(true). Strict OpenAI-compatible backends and forwarding
+// proxies (LiteLLM) reject the unknown field with HTTP 400, so it must be
+// absent by default.
+func TestRequest_CachePromptGating(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    bool
+	}{
+		{name: "Default_NoCachePrompt", enabled: false, want: false},
+		{name: "WithCachePrompt_Sent", enabled: true, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(
+					`data: {"id":"x","object":"chat.completion.chunk","choices":[{"delta":{"content":"ok"},"finish_reason":"stop","index":0}]}` + "\n\n",
+				))
+				_, _ = w.Write([]byte("data: [DONE]\n\n"))
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			}))
+			defer srv.Close()
+
+			opts := []options.Option[openai.Provider]{openai.WithBaseURL(srv.URL)}
+			if tc.enabled {
+				opts = append(opts, openai.WithCachePrompt(true))
+			}
+			provider, err := openai.NewProvider("test-key", opts...)
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+
+			seq, err := provider.Complete(context.Background(), llm.CompletionRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hi"}},
+				Stream:   true,
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			for range seq {
+			}
+
+			var body map[string]any
+			if err := json.Unmarshal(captured, &body); err != nil {
+				t.Fatalf("unmarshal request body: %v\nbody: %s", err, captured)
+			}
+			_, got := body["cache_prompt"]
+			if got != tc.want {
+				t.Errorf("cache_prompt present = %v, want %v (body: %s)", got, tc.want, captured)
+			}
+		})
+	}
+}

--- a/zkit/ai/llm/openai/provider.go
+++ b/zkit/ai/llm/openai/provider.go
@@ -42,6 +42,14 @@ type Provider struct {
 	// Field to Strip semantics. When nil, every assistant message
 	// in Field mode keeps its reasoning_content.
 	reasoningKeepMask func([]llm.Message) []bool
+	// cachePrompt sends the non-standard top-level `cache_prompt: true`
+	// field on every request. It is a llama.cpp server extension (KV-cache
+	// reuse across matching prefixes) and OFF by default: strict
+	// OpenAI-compatible backends — hosted OpenAI, and proxies like LiteLLM
+	// that forward unknown params to the upstream — reject the unknown
+	// field with HTTP 400. Only the llama.cpp construction paths enable it
+	// via [WithCachePrompt].
+	cachePrompt bool
 }
 
 const (
@@ -151,7 +159,7 @@ func (p *Provider) streamCompletion(ctx context.Context, req llm.CompletionReque
 	// inject it as an extra top-level JSON field via WithJSONSet.
 	// Providers that don't recognise the key ignore it.
 	stream := p.client.Chat.Completions.NewStreaming(ctx, params,
-		extraJSONOptions(req)...)
+		p.extraJSONOptions(req)...)
 
 	// OpenAI streams tool calls as deltas keyed by Index — the first
 	// delta for an index carries the ID + Name; subsequent deltas are
@@ -431,7 +439,7 @@ func (p *Provider) nonStreamCompletion(
 
 	// Create completion (see extraJSONOptions for chat_template_kwargs handling).
 	completion, err := p.client.Chat.Completions.New(ctx, params,
-		extraJSONOptions(req)...)
+		p.extraJSONOptions(req)...)
 	if err != nil {
 		yield(llm.CompletionChunk{Done: true}, fmt.Errorf("completion: %w", err))
 		return
@@ -475,19 +483,21 @@ func (p *Provider) nonStreamCompletion(
 // but option.WithJSONSet lets us slip them in via the underlying
 // *bytes.Buffer.
 //
-// Always injects `cache_prompt: true` — llama.cpp's server respects
-// it (reuses the KV-cache for any matching prefix, which is a huge
+// `cache_prompt: true` is injected only when the provider was built
+// with [WithCachePrompt] (the llama.cpp paths). llama.cpp's server
+// respects it — reusing the KV-cache for any matching prefix, a huge
 // win across iterations of a turn AND across turns whose system
-// prompt + early history is unchanged); hosted OpenAI / vLLM /
-// other strict-but-tolerant servers ignore unknown top-level
-// fields. Effectively free for non-llama backends, large saving
-// for llama backends.
+// prompt + early history is unchanged. It is NOT sent otherwise:
+// strict OpenAI-compatible backends, and proxies like LiteLLM that
+// forward unknown params upstream, reject the unrecognised field with
+// HTTP 400.
 //
 // Returns the option slice the callers spread into their
 // NewStreaming/New variadics.
-func extraJSONOptions(req llm.CompletionRequest) []option.RequestOption {
-	opts := []option.RequestOption{
-		option.WithJSONSet("cache_prompt", true),
+func (p *Provider) extraJSONOptions(req llm.CompletionRequest) []option.RequestOption {
+	var opts []option.RequestOption
+	if p.cachePrompt {
+		opts = append(opts, option.WithJSONSet("cache_prompt", true))
 	}
 	if len(req.ChatTemplateKwargs) > 0 {
 		opts = append(opts, option.WithJSONSet("chat_template_kwargs", req.ChatTemplateKwargs))
@@ -784,6 +794,17 @@ func WithHTTPClient(client *http.Client) options.Option[Provider] {
 			}
 			p.client = openai.NewClient(clientOpts...)
 		}
+	}
+}
+
+// WithCachePrompt enables the non-standard `cache_prompt: true` top-level
+// request field. It is a llama.cpp server extension (KV-cache prefix reuse)
+// and must only be set for llama.cpp-backed providers — strict
+// OpenAI-compatible backends and forwarding proxies (LiteLLM) reject the
+// unknown field with HTTP 400. Off by default.
+func WithCachePrompt(enabled bool) options.Option[Provider] {
+	return func(p *Provider) {
+		p.cachePrompt = enabled
 	}
 }
 


### PR DESCRIPTION
## Problem

Adding a LiteLLM provider via the OpenAI-compatible endpoint lets you list and select models, but **submitting a chat request fails with HTTP 400**.

Root cause: the shared OpenAI-compatible provider injected a non-standard top-level `cache_prompt: true` on **every** chat request. `cache_prompt` is a llama.cpp server extension (KV-cache prefix reuse). Strict OpenAI-compatible backends — and forwarding proxies like LiteLLM that pass unknown params straight upstream — reject the unrecognised field with `400 Bad Request`.

Model listing kept working because that request carries no body extras. The 400 only ever appeared on submit, and only against non-llama.cpp backends (the default provider is llama.cpp, which accepts the field).

## Fix

Make `cache_prompt` opt-in and enable it only on genuine llama.cpp paths:

- `openai`: new `cachePrompt` field + `WithCachePrompt` option; `extraJSONOptions` now a method that emits the field only when set.
- `llamacpp` facade and `zarlai` `LlamaCppClient`: pass `WithCachePrompt(true)`.
- `backends` registry/adapter: thread a `cachePrompt` flag through `buildParams`, set `true` only for the llama.cpp built-in (`def.Builtin && def.Name == DefaultBuiltinName.String()`).

Side benefit: hosted OpenAI, DeepSeek, Ollama, and custom DB-backed providers no longer leak `cache_prompt` through the shared adapter.

## Tests

- New `cache_prompt_test.go` pins both directions (absent by default, present with `WithCachePrompt`).
- `zkit/ai/llm/...` and `zarlai/service` suites pass; full build green.