### PR TITLE
fix: resolve build output conflicts in CI and release pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,14 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-
       - name: build
         working-directory: ${{ matrix.module }}
         run: go build ./...
+        if: matrix.module != 'zarlcode'
+      - name: build (zarlcode)
+        working-directory: ${{ matrix.module }}
+        run: go list ./... | grep -v '/cmd$' | xargs go build
+        if: matrix.module == 'zarlcode'
 
       - name: vet
         working-directory: ${{ matrix.module }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
           - { goos: linux, goarch: arm64 }
           - { goos: darwin, goarch: amd64 }
           - { goos: darwin, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
     steps:
       - uses: actions/checkout@v6
 
@@ -55,26 +54,25 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
           TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          VERSION="${TAG#zarlcode/}"   # zarlcode/v1.2.3 -> v1.2.3
-          ldflags="-s -w -X github.com/zarldev/zarlmono/zarlcode/version.version=${VERSION}"
-          bin="zarlcode"
-          [ "${GOOS}" = "windows" ] && bin="zarlcode.exe"
-          go build -trimpath -ldflags "${ldflags}" -o "${bin}" ./zarlcode/cmd
-
-          base="zarlcode_${VERSION}_${GOOS}_${GOARCH}"
-          mkdir -p dist
-          if [ "${GOOS}" = "windows" ]; then
-            archive="${base}.zip"
-            zip -q "dist/${archive}" "${bin}"
-          else
-            archive="${base}.tar.gz"
-            tar -czf "dist/${archive}" "${bin}"
+DOQ3|        run: |
+tZ6/|          set -euo pipefail
+25tL|          VERSION="${TAG#zarlcode/}"   # zarlcode/v1.2.3 -> v1.2.3
+hHLy|          ldflags="-s -w -X github.com/zarldev/zarlmono/zarlcode/version.version=${VERSION}"
+b81g|          bin="zarlcode"
+om/q|          [ "${GOOS}" = "windows" ] && bin="zarlcode.exe"
+91kS|          mkdir -p dist
+47DE|          go build -trimpath -ldflags "${ldflags}" -o "dist/${bin}" ./zarlcode/cmd
+47DE|
+Wa01|          base="zarlcode_${VERSION}_${GOOS}_${GOARCH}"
+wowk|          if [ "${GOOS}" = "windows" ]; then
+zngk|            archive="${base}.zip"
+gSEH|            zip -q "dist/${archive}" "dist/${bin}"
+ZfXq|          else
+mbSo|            archive="${base}.tar.gz"
+            tar -czf "dist/${archive}" "dist/${bin}"
           fi
           ( cd dist && sha256sum "${archive}" > "${archive}.sha256" )
           echo "packaged dist/${archive}"
-
       - name: upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.1.0] — 2025-XX-XX
+
+### Initial release
+
+First public release of `zarlmono` — the Zarldev monorepo.
+
+#### Modules
+
+| Module | Tag | What it is |
+|---|---|---|
+| `zkit` | `zkit/v0.1.0` | Shared library: agent runner, LLM providers, tool system, guardrails, compaction, MCP, cache, filesystem, HTTP/RPC, logging, notifications, sync primitives |
+| `zarlcode` | `zarlcode/v0.1.0` | Terminal coding agent / TUI — plan first, execute second, rewind anytime |
+| `zarlai` | — | Smart-home/multimodal assistant (excluded from standard CI; CGO deps) |
+| `swebench-eval` | `swebench-eval/v0.1.0` | SWE-bench evaluation driver |
+| `examples` | — | Deterministic harness demos (not a consumer module) |
+
+#### zarlcode
+
+- **Plan/Build modes** — `Shift+Tab` toggles read-only Plan (investigation) and full Build (execute) modes
+- **Session persistence** — sessions saved to `~/.zarlcode/state.db`; resume with `-continue`
+- **Headless mode** — `--headless --prompt-file task.md` for CI, scripts, eval harnesses
+- **Self-upgrade** — `zarlcode upgrade` downloads and replaces the binary
+- **Release pipeline** — `task zarlcode:release VERSION=vX.Y.Z` tags and pushes
+- **Settings system** — workspace/global scope, promote (Ctrl+G), inline save feedback, storage inspector
+- **Provider support** — anthropic, openai, deepseek, gemini, google-vertex, llamacpp, ollama, claude-code (OAuth), openai-codex (OAuth)
+- **File tools** — read, write, edit, apply_patch, grep, glob — workspace-bounded and tracked
+- **Shell tools** — foreground (600s max) and background modes with guardrail policies
+- **MCP servers** — stdio and HTTP transports; tools register on the flat tool list
+- **Sub-agents** — parallel dispatch with mode enforcement (explore/verify/implement)
+- **Compaction** — structural, summary, and executive strategies for long sessions
+- **Skills** — hot-reloadable capability guides from workspace/home/source-tree directories
+- **Theme system** — palette, JSON loader, live-preview gallery in settings
+
+#### zkit (shared library)
+
+- **Agent runner** — `think → call tools → observe → repeat` loop with streaming, compaction, truncation, steering
+- **LLM providers** — OpenAI, Anthropic, Google Gemini, DeepSeek, llama.cpp, Ollama, Claude Code (OAuth), OpenAI Codex (OAuth)
+- **Tool system** — typed handlers with reflected JSON Schema, registry, MCP bridge, code tools, fetch, search, dynamic registration
+- **Guardrails** — pre/post tool-call validation, shell policy, fan-out caps, schema validation
+- **Compaction** — structural trimming, LLM summaries, adaptive pressure handling
+- **Stability tiers** — core/stable, shared/stable-ish, beta/evolving, experimental/volatile (documented in `zkit/README.md`)
+- **Infrastructure** — cache, docstore, filesystem, messagebus, vectorstore, skills, notifications, sync primitives
+
+#### swebench-eval
+
+- Standalone SWE-bench evaluation driver that shares the same agent assembly as `zarlcode` via `zkit/agent/coderunner`
+
+#### Bug fixes
+
+- Fixed claudecode inline `<assistant_tool_calls>` emitted as text ([#1])
+- Fixed recovery interceptor panic propagation
+- Fixed golangci-lint exclusion rules across all modules
+- Added gosec G101/G204 exclusions for specific files
+- Fixed cache_prompt gating to llama.cpp backends only
+
+#### Documentation
+
+- Comprehensive AGENTS.md files in all major packages
+- zkit README with package map, stability tiers, dependency policy
+- Contributing guide with workflow, style, and gotchas
+- Documentation site (Astro Starlight → GitHub Pages)
+
+---
+
+### Unreleased
+
+_No changes yet._
+
+[v0.1.0]: https://github.com/zarldev/zarlmono/releases/tag/placeholder

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,66 @@
+# Release Checklist
+
+Use this checklist before each release.
+
+## Pre-release
+
+- [ ] `go tool task check` — build + vet + test passes on all CI modules
+- [ ] `go tool task lint` — golangci-lint passes on all CI modules
+- [ ] `go tool task race` — zkit race tests pass
+- [ ] Working tree is clean (`git status` shows nothing)
+- [ ] CHANGELOG.md updated with all changes since last release
+- [ ] Date in CHANGELOG.md is correct
+- [ ] No `go get -u` was run (which would re-bump `jsonschema` past v0.13.0)
+
+## Tagging
+
+### zkit (shared library) — required
+
+```bash
+git tag -a zkit/v0.1.0 -m "zkit vX.Y.Z — <summary>"
+git push origin zkit/v0.1.0
+```
+
+### zarlcode (TUI product) — required
+
+```bash
+go tool task zarlcode:release VERSION=vX.Y.Z
+```
+
+This creates `zarlcode/vX.Y.Z`, validates the version format, checks for a clean tree, and pushes the tag. The Taskfile task is the canonical path — it also ensures the `zarlcode` binary's ldflags version string matches.
+
+### swebench-eval (eval tool) — optional but recommended
+
+```bash
+git tag -a swebench-eval/v0.1.0 -m "swebench-eval vX.Y.Z — <summary>"
+git push origin swebench-eval/v0.1.0
+```
+
+### zarlai (assistant app) — defer until stable
+
+`zarlai` is excluded from standard CI and has CGO system dependencies. No release pipeline exists yet. Tag when:
+- CI job for `zarlai` is added (or the exclusion is justified)
+- A `task zarlai:release` is added to `Taskfile.yml`
+- The binary builds reliably in CI environments
+
+## Post-release
+
+- [ ] Push CHANGELOG.md
+- [ ] Verify tags on GitHub: `git tag -l | sort`
+- [ ] Update GitHub Releases page with the release body (copy from CHANGELOG)
+- [ ] Announce in relevant channels (Discord, etc.)
+
+## Versioning rules
+
+- **Pre-v1**: APIs may evolve. Stable-tier packages should avoid breaking changes.
+- **Tag format**: `module/vX.Y.Z` — the module name is the prefix, not the repo name.
+- **Go module consumers** use `go get github.com/zarldev/zarlmono/zkit@zkit/v0.1.0` to pin.
+- **zarlcode** consumers use `go get github.com/zarldev/zarlmono/zarlcode@zarlcode/v0.1.0` or the self-upgrade command.
+
+## Next release (v0.2.0)
+
+When v0.2.0 is ready:
+1. Bump version in CHANGELOG.md
+2. Run the checklist above
+3. Consider whether any beta packages have matured to shared/stable tier
+4. Consider adding `zarlai` to the standard CI matrix if CGO deps are resolved


### PR DESCRIPTION
## What this fixes

### CI pipeline — go build ./... in zarlcode fails
`go build ./...` tries to build `./cmd` (a main package) and output it as `cmd`, but `cmd/` is already a directory. Fixed by excluding `/cmd` from the build pattern for the zarlcode module.

### Release pipeline — go build -o zarlcode fails
`go build -o zarlcode ./zarlcode/cmd` tries to write `zarlcode` at the repo root, but `zarlcode/` is a directory. Fixed by building into `dist/`.

### Release pipeline — Windows cross-compilation fails
`zkit/ai/tools/code/bash.go` and `processmgr.go` use Unix `syscall.Kill`/`Setsid` — no Windows equivalents. Dropped `windows/amd64` from the release matrix.

## Also included
- `CHANGELOG.md` for v0.1.0
- `RELEASE.md` — release checklist for future releases