### PR TITLE
OAuth and Codex provider cleanup

### DIFF
--- a/zkit/ai/llm/claudecode/provider.go
+++ b/zkit/ai/llm/claudecode/provider.go
@@ -262,8 +262,7 @@ func buildPrompt(req llm.CompletionRequest) string {
 		}
 		fmt.Fprintf(&b, "<%s>\n%s\n</%s>\n\n", role, content, role)
 		if len(m.ToolCalls) > 0 {
-			raw, _ := json.Marshal(m.ToolCalls)
-			fmt.Fprintf(&b, "<assistant_tool_calls>\n%s\n</assistant_tool_calls>\n\n", raw)
+			fmt.Fprintf(&b, "<assistant_tool_calls>\n%s\n</assistant_tool_calls>\n\n", renderToolCalls(m.ToolCalls))
 		}
 	}
 	if len(req.Tools) > 0 {
@@ -277,6 +276,43 @@ func buildPrompt(req llm.CompletionRequest) string {
 	}
 	b.WriteString(responseFormatDirective(req.ResponseFormat))
 	return b.String()
+}
+
+// renderToolCalls serializes prior assistant tool calls into the same flat
+// {id, name, arguments} shape the tool-calling protocol directive documents,
+// with arguments as a live JSON object rather than a stringified blob.
+//
+// The transport ToolCall is the OpenAI nesting (a "function" wrapper whose
+// "arguments" is a JSON-*encoded string*). Echoing that verbatim into the
+// prompt taught the model a format that contradicts the directive, and the
+// model — priming on the rendered history over the instruction — copied the
+// double-stringified arguments and routinely fumbled the inner escaping,
+// producing invalid JSON that toolparse can't recover, so the call leaked
+// back as visible text. Rendering the documented shape removes the conflict
+// and the escaping hazard; toolparse.ParseArtifact recovers it either way.
+func renderToolCalls(calls []llm.ToolCall) string {
+	type flatCall struct {
+		ID        string          `json:"id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	out := make([]flatCall, 0, len(calls))
+	for _, c := range calls {
+		args := strings.TrimSpace(c.Function.Arguments)
+		if args == "" || !json.Valid([]byte(args)) {
+			args = "{}"
+		}
+		out = append(out, flatCall{
+			ID:        c.ID,
+			Name:      c.Function.Name,
+			Arguments: json.RawMessage(args),
+		})
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return "[]"
+	}
+	return string(raw)
 }
 
 // responseFormatDirective is claudecode's best-effort honoring of

--- a/zkit/ai/llm/claudecode/provider_internal_test.go
+++ b/zkit/ai/llm/claudecode/provider_internal_test.go
@@ -5,7 +5,37 @@ import (
 	"testing"
 
 	"github.com/zarldev/zarlmono/zkit/ai/llm"
+	"github.com/zarldev/zarlmono/zkit/ai/llm/toolparse"
 )
+
+// TestRenderedToolCallHistoryRoundTrips guards the format-conflict fix: the
+// <assistant_tool_calls> block buildPrompt renders for prior turns is the same
+// shape the model copies into a new turn, so it must parse back into the
+// original call via toolparse.ParseArtifact. Rendering the old double-
+// stringified arguments blob let the model fumble the escaping and leak the
+// call as visible text.
+func TestRenderedToolCallHistoryRoundTrips(t *testing.T) {
+	calls := []llm.ToolCall{{
+		ID:   "call_1",
+		Type: toolCallTypeFunction,
+		Function: llm.ToolCallFunction{
+			Name:      "bash",
+			Arguments: `{"command":"echo hi","timeout_seconds":20}`,
+		},
+	}}
+	block := "<assistant_tool_calls>\n" + renderToolCalls(calls) + "\n</assistant_tool_calls>"
+	res := toolparse.ParseArtifact(block)
+	if len(res.Calls) != 1 {
+		t.Fatalf("ParseArtifact recovered %d calls, want 1, from:\n%s", len(res.Calls), block)
+	}
+	got := res.Calls[0]
+	if got.Function.Name != "bash" {
+		t.Fatalf("recovered name %q, want bash", got.Function.Name)
+	}
+	if want := `"command":"echo hi"`; !strings.Contains(got.Function.Arguments, want) {
+		t.Fatalf("recovered arguments %q missing %q", got.Function.Arguments, want)
+	}
+}
 
 func TestTextDeltaFromStreamEvent(t *testing.T) {
 	line := `{"type":"stream_event","event":{"delta":{"type":"text_delta","text":"hello"}}}`
@@ -76,7 +106,7 @@ func TestBuildPromptIncludesToolResults(t *testing.T) {
 	if want := `"name":"bash"`; !strings.Contains(prompt, want) {
 		t.Fatalf("prompt missing tool call name %q in:\n%s", want, prompt)
 	}
-	if want := `"arguments":"{\"command\":\"echo hi\"}"`; !strings.Contains(prompt, want) {
+	if want := `"arguments":{"command":"echo hi"}`; !strings.Contains(prompt, want) {
 		t.Fatalf("prompt missing tool call arguments %q in:\n%s", want, prompt)
 	}
 	if want := "<tool_result tool_call_id=\"call_1\">\nhi\n\n</tool_result>"; !strings.Contains(prompt, want) {

--- a/zkit/ai/llm/openaicodex/responses_internal_test.go
+++ b/zkit/ai/llm/openaicodex/responses_internal_test.go
@@ -100,6 +100,41 @@ func TestParseSSEStream_ReasoningRoutesToThinkingChannel(t *testing.T) {
 	}
 }
 
+func TestParseSSEStream_ReasoningSummaryPartsSeparated(t *testing.T) {
+	t.Parallel()
+	// A multi-part summary: each part is bracketed by a *.part.added /
+	// *.text.done pair and its deltas carry no leading separator. The
+	// parser must inject a paragraph break at each part boundary so the
+	// concatenated thinking reads "part one.\n\npart two." rather than
+	// running together as "part one.part two."
+	stream := strings.Join([]string{
+		`data: {"type":"response.reasoning_summary_part.added","summary_index":0}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.delta","delta":"Checked CI."}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.done"}`,
+		``,
+		`data: {"type":"response.reasoning_summary_part.added","summary_index":1}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.delta","delta":"Now pushing the fix."}`,
+		``,
+		`data: {"type":"response.completed","response":{"usage":{}}}`,
+		``,
+	}, "\n")
+	chunks, err := collectChunks(t, stream)
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+	var thinking strings.Builder
+	for _, c := range chunks {
+		thinking.WriteString(c.Thinking)
+	}
+	const want = "Checked CI.\n\nNow pushing the fix."
+	if got := thinking.String(); got != want {
+		t.Errorf("thinking = %q, want %q", got, want)
+	}
+}
+
 func TestParseSSEStream_ToolCall(t *testing.T) {
 	t.Parallel()
 	stream := strings.Join([]string{

--- a/zkit/ai/llm/openaicodex/responses_sse.go
+++ b/zkit/ai/llm/openaicodex/responses_sse.go
@@ -181,6 +181,13 @@ type sseState struct {
 	// output_item.added event.
 	toolCallByIdx map[int]*pendingToolCall
 	toolCallByID  map[string]*pendingToolCall
+	// reasoningEmitted records whether any reasoning delta has been
+	// yielded on the Thinking channel. The summary streams as discrete
+	// parts (a *.summary_part.added event precedes each), so we use this
+	// to insert a paragraph break between parts — without it, the last
+	// delta of one part and the first of the next concatenate with no
+	// space ("...poll.Need check..."), running the whole summary together.
+	reasoningEmitted bool
 }
 
 type pendingToolCall struct {
@@ -222,7 +229,6 @@ func (s *sseState) dispatch(payload string, yield func(llm.CompletionChunk, erro
 	//                                             (some ChatGPT-account
 	//                                             models bypass the
 	//                                             summary entirely)
-	//   response.reasoning_part.added             part metadata; ignored
 	// All variants funnel through the same handler and route to the
 	// runner's out-of-band Thinking channel.
 	case "response.reasoning_summary_text.delta",
@@ -236,7 +242,20 @@ func (s *sseState) dispatch(payload string, yield func(llm.CompletionChunk, erro
 		if ev.Delta == "" {
 			return false
 		}
+		s.reasoningEmitted = true
 		if !yield(llm.CompletionChunk{Thinking: ev.Delta}, nil) {
+			return true
+		}
+	// A new summary part begins. The summary is split into parts whose
+	// text deltas carry no leading separator, so emit a paragraph break
+	// before the part's deltas start — but only once a prior part has
+	// already streamed, so the first part isn't prefixed with blank lines.
+	case "response.reasoning_summary_part.added",
+		"response.reasoning_part.added":
+		if !s.reasoningEmitted {
+			return false
+		}
+		if !yield(llm.CompletionChunk{Thinking: "\n\n"}, nil) {
 			return true
 		}
 	case "response.reasoning_summary_text.done",

--- a/zkit/oauth/codex/login.go
+++ b/zkit/oauth/codex/login.go
@@ -222,8 +222,10 @@ func makeCallbackHandler(expectedState string, resCh chan<- callbackResult) http
 
 // openBrowser tries to open the given URL in the user's default
 // browser. Failures are silent — the caller has already printed the
-// URL for the user to copy/paste as a fallback.
-func openBrowser(ctx context.Context, url string) {
+// URL for the user to copy/paste as a fallback. It's a var so tests
+// driving runManual/RunLogin can stub it: running the real one would
+// spawn a ChatGPT login tab on every `go test` of this package.
+var openBrowser = func(ctx context.Context, url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":

--- a/zkit/oauth/codex/login_internal_test.go
+++ b/zkit/oauth/codex/login_internal_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/zarldev/zarlmono/zkit/prefs"
 )
 
+// stubBrowser replaces the package's openBrowser with a no-op for the
+// duration of the test and restores it after. Without this, runManual /
+// RunLogin shell out to the real xdg-open, spawning a ChatGPT login tab
+// every time the package's tests run.
+func stubBrowser(t *testing.T) {
+	t.Helper()
+	prev := openBrowser
+	openBrowser = func(context.Context, string) {}
+	t.Cleanup(func() { openBrowser = prev })
+}
+
 // TestMakeOAuthHandler_HappyPath drives the callback handler with the
 // canonical "code + correct state" callback the browser would send.
 func TestMakeOAuthHandler_HappyPath(t *testing.T) {
@@ -73,6 +84,7 @@ func TestMakeOAuthHandler_StateMismatchRejectsWithoutUnblocking(t *testing.T) {
 // end-to-end: builds a fresh flow, pretends the user pasted the
 // matching code+state, and verifies the persisted credential.
 func TestRunOAuthLoginManual_EndToEnd(t *testing.T) {
+	stubBrowser(t)
 	store, v := openTestStoreAndVault(t)
 
 	jwt := makeJWTPayload(t, "acct_manual")
@@ -128,6 +140,7 @@ func TestRunOAuthLoginManual_EndToEnd(t *testing.T) {
 // proceed if the pasted state doesn't match the flow we generated —
 // even if the code looks plausible.
 func TestRunOAuthLoginManual_StateMismatch(t *testing.T) {
+	stubBrowser(t)
 	store, v := openTestStoreAndVault(t)
 	flow, err := openaicodex.CreateAuthorizationFlow()
 	if err != nil {
@@ -142,6 +155,7 @@ func TestRunOAuthLoginManual_StateMismatch(t *testing.T) {
 }
 
 func TestRunOAuthLoginManual_RawCodeRejected(t *testing.T) {
+	stubBrowser(t)
 	store, v := openTestStoreAndVault(t)
 	flow, err := openaicodex.CreateAuthorizationFlow()
 	if err != nil {


### PR DESCRIPTION
Carry-over from the sidebar/headless/guardrails branch. Cleans up OAuth codex login and Claude/OpenAI Codex provider internals.