### PR TITLE
Configure release dispatch git author

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -222,6 +222,9 @@ jobs:
           VERSION: ${{ steps.plan.outputs.version }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           IFS=',' read -r -a tags <<< "$TAGS"
           for tag in "${tags[@]}"; do
             module="${tag%%/*}"


### PR DESCRIPTION
Annotated tag creation in release-dispatch needs git user.name/user.email. Configure the GitHub Actions bot identity before creating release tags.