### PR TITLE
Dispatch zarlcode release workflow explicitly

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -246,22 +246,19 @@ jobs:
           VERSION: ${{ steps.plan.outputs.version }}
         run: |
           set -euo pipefail
-          echo "waiting for release.yml to pick up zarlcode/${VERSION}…"
+          tag="zarlcode/${VERSION}"
+          echo "dispatching release.yml for ${tag}…"
+          gh workflow run release.yml --ref main -f tag="${tag}"
           for i in $(seq 1 30); do
             sleep 10
-            run_id=$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs?per_page=5&event=push" \
-              --jq '.workflow_runs[] | select(.head_branch == "zarlcode/'"${VERSION}"'") | .id' \
-              2>/dev/null || true)
-            if [ -n "$run_id" ]; then
+            run_id=$(gh api               "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs?per_page=10&event=workflow_dispatch"               --jq '.workflow_runs[0].id'               2>/dev/null || true)
+            if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
               echo "found run ${run_id} — waiting for completion"
-              gh run watch "$run_id" --exit-status && \
-                echo "release.yml completed successfully" && \
-                exit 0
+              gh run watch "$run_id" --exit-status &&                 echo "release.yml completed successfully" &&                 exit 0
               echo "release.yml failed" >&2
               exit 1
             fi
             echo "waiting for workflow to appear… (${i}/30)"
           done
-          echo "timed out waiting for release.yml to pick up zarlcode/${VERSION}" >&2
+          echo "timed out waiting for release.yml dispatch for ${tag}" >&2
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ name: release
 on:
   push:
     tags: ["zarlcode/v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "zarlcode tag to publish, e.g. zarlcode/v0.1.3"
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -51,7 +57,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG#zarlcode/}"   # zarlcode/v1.2.3 -> v1.2.3
@@ -108,7 +114,7 @@ jobs:
       - name: publish github release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
           # The release keeps the full submodule tag; the title is the bare version.


### PR DESCRIPTION
Tags pushed with GITHUB_TOKEN do not trigger downstream workflows. Add workflow_dispatch support to release.yml and have release-dispatch invoke it explicitly for zarlcode releases.