### PR TITLE
Ignore legacy upgrade source paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ First public release of `zarlmono` — the Zarldev monorepo.
 
 ---
 
+## [v0.1.4] — 2026-06-25
+
+### Fixed
+
+- `zarlcode upgrade` now ignores and clears legacy local source path configuration, falling back to GitHub release upgrades instead of requiring a source checkout.
+
 ## [v0.1.3] — 2026-06-24
 
 ### Added
@@ -116,6 +122,7 @@ First public release of `zarlmono` — the Zarldev monorepo.
 
 - Initial public release of the Zarldev monorepo
 
+[v0.1.4]: https://github.com/zarldev/zarlmono/releases/tag/zarlcode/v0.1.4
 [v0.1.3]: https://github.com/zarldev/zarlmono/releases/tag/zarlcode/v0.1.3
 [v0.1.2]: https://github.com/zarldev/zarlmono/releases/tag/zarlcode/v0.1.2
 [v0.1.1]: https://github.com/zarldev/zarlmono/releases/tag/zarlcode/v0.1.1

--- a/zarlcode/cli/upgrade.go
+++ b/zarlcode/cli/upgrade.go
@@ -229,6 +229,10 @@ func resolveUpgradeRepo(ctx context.Context, svc *prefs.Service) (string, error)
 	} else if ok && strings.TrimSpace(v.Value) != "" {
 		repo := strings.TrimSpace(v.Value)
 		if err := validateUpgradeSource(repo); err != nil {
+			if looksLikeLegacyUpgradeSourcePath(repo) {
+				_ = svc.DeleteSetting(ctx, prefs.ScopeGlobal, settingKeyUpgradeSource)
+				return defaultUpgradeRepo, nil
+			}
 			return "", fmt.Errorf("configured source %q: %w", repo, err)
 		}
 		return repo, nil
@@ -278,6 +282,20 @@ func validateUpgradeSource(repo string) error {
 		return errors.New(`want a GitHub repository slug "owner/repo"`)
 	}
 	return nil
+}
+
+func looksLikeLegacyUpgradeSourcePath(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if filepath.IsAbs(value) || strings.HasPrefix(value, "~") || strings.HasPrefix(value, ".") {
+		return true
+	}
+	if strings.Contains(value, string(filepath.Separator)) {
+		return true
+	}
+	return strings.Contains(value, `\`)
 }
 
 // normalizeUpgradeSource canonicalizes a repo slug, also accepting a full

--- a/zarlcode/cli/upgrade_internal_test.go
+++ b/zarlcode/cli/upgrade_internal_test.go
@@ -188,6 +188,27 @@ func TestUpgradeSettingsCommandsPersistGlobally(t *testing.T) {
 	}
 }
 
+func TestResolveUpgradeRepoMigratesLegacySourcePath(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	svc := prefs.NewService(store, nil, "")
+	legacyPath := filepath.Join(t.TempDir(), "zarlmono")
+	if err := svc.SetSetting(ctx, prefs.ScopeGlobal, settingKeyUpgradeSource, legacyPath); err != nil {
+		t.Fatalf("set legacy source: %v", err)
+	}
+
+	repo, err := resolveUpgradeRepo(ctx, svc)
+	if err != nil {
+		t.Fatalf("resolve repo: %v", err)
+	}
+	if repo != defaultUpgradeRepo {
+		t.Fatalf("repo = %q, want default %q", repo, defaultUpgradeRepo)
+	}
+	if _, ok, err := svc.GetSetting(ctx, prefs.ScopeGlobal, settingKeyUpgradeSource); err != nil || ok {
+		t.Fatalf("legacy source not cleared: ok=%v err=%v", ok, err)
+	}
+}
+
 func TestRunUpgradeDryRunDoesNotDownload(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
Migrates legacy upgrade_source values that point at local source directories by clearing them and falling back to the default GitHub release repo. This prevents `zarlcode upgrade` from requiring a source checkout for users with old config.

Checks run locally:
- go test -C zarlcode ./cli -run 'TestResolveUpgradeRepoMigratesLegacySourcePath|TestUpgradeSettingsCommandsPersistGlobally|TestNormalizeUpgradeSource'
- go test -C zarlcode ./cli
- go build -o /tmp/zarlcode ./zarlcode/cmd