### PR TITLE
Grant actions: write so release-dispatch can trigger the publisher

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -48,6 +48,11 @@ concurrency:
 
 permissions:
   contents: write
+  # The "verify zarlcode release workflow" step calls `gh workflow run
+  # release.yml`, which the GITHUB_TOKEN can only do with actions: write.
+  # Without it that dispatch returns HTTP 403 (Resource not accessible by
+  # integration) and the publisher never runs off a dispatch.
+  actions: write
 
 jobs:
   plan-and-release:


### PR DESCRIPTION
## Problem

The `release-dispatch` workflow's `verify zarlcode release workflow` step calls `gh workflow run release.yml`, but the workflow only declares `permissions: contents: write`. Triggering another workflow needs `actions: write`, so the call fails:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

Observed live on the zarlcode v0.1.5 release: the tag was pushed, but the publisher dispatch 403'd and `release.yml` had to be run by hand. (A `GITHUB_TOKEN`-pushed tag does not auto-trigger `release.yml`, so the dispatch is the only automated path.)

## Fix

Add `actions: write` to the workflow's `permissions` block.

## Not covered here

The Homebrew tap auto-update is separately broken (app-token "Integration not found"); the tap formula is stuck at v0.1.2. That needs a GitHub App install/secret fix, not a workflow permission.