### PR TITLE
Point zarlcode at zkit v0.5.0

### DIFF
--- a/go.work
+++ b/go.work
@@ -9,4 +9,4 @@ use (
 	./zkit
 )
 
-replace github.com/zarldev/zarlmono/zkit v0.4.0 => ./zkit
+replace github.com/zarldev/zarlmono/zkit v0.5.0 => ./zkit

--- a/zarlcode/go.mod
+++ b/zarlcode/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
-	github.com/zarldev/zarlmono/zkit v0.4.0
+	github.com/zarldev/zarlmono/zkit v0.5.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
Release step for zarlcode v0.6.0: bump the zkit dependency (go.mod require + go.work replace) to the freshly tagged zkit/v0.5.0. Build verified via `go tool task build`.