### PR TITLE
Drop grep and head from the shell read-tool policy

### DIFF
--- a/zkit/agent/guardrails/shell_guardrail_test.go
+++ b/zkit/agent/guardrails/shell_guardrail_test.go
@@ -29,7 +29,7 @@ func TestShellGuardrail_SafeCommandPasses(t *testing.T) {
 func TestShellGuardrail_ShellReadToolRejectsWithGuidance(t *testing.T) {
 	t.Parallel()
 	g := guardrails.NewShellGuardrail("bash")
-	err := g.Before(t.Context(), bashCall("grep -r TODO . | head -20"))
+	err := g.Before(t.Context(), bashCall("cat main.go"))
 	if err == nil {
 		t.Fatal("shell read tool: want Validation rejection")
 	}
@@ -39,6 +39,16 @@ func TestShellGuardrail_ShellReadToolRejectsWithGuidance(t *testing.T) {
 	}
 	if !strings.Contains(e.Reason, "registered workspace tools") {
 		t.Errorf("Reason should suggest workspace tools: %q", e.Reason)
+	}
+}
+
+// grep is no longer a shell read tool — filtering real command output with it
+// passes the guardrail.
+func TestShellGuardrail_GrepAllowed(t *testing.T) {
+	t.Parallel()
+	g := guardrails.NewShellGuardrail("bash")
+	if err := g.Before(t.Context(), bashCall("grep -r TODO . | head -20")); err != nil {
+		t.Fatalf("grep should pass the shell policy, got: %v", err)
 	}
 }
 

--- a/zkit/agent/shellpolicy/ir.go
+++ b/zkit/agent/shellpolicy/ir.go
@@ -56,7 +56,7 @@ const (
 	ReasonRedirect ReasonCode = "redirect"
 
 	// ReasonShellReadTool indicates the command is using a shell file-discovery
-	// helper (`grep`, `sed -n`, `find`, `head`, `tail`, `cat`, etc.) even though
+	// helper (`sed -n`, `find`, `tail`, `cat`, etc.; grep and head are excluded) even though
 	// workspace-aware read/search/list tools can do that job with bounded,
 	// structured output. Treated as Block in the standard profile so the model
 	// gets a direct correction instead of burning context on shell pipelines.

--- a/zkit/agent/shellpolicy/policy.go
+++ b/zkit/agent/shellpolicy/policy.go
@@ -62,9 +62,10 @@ func NewPolicyEngine(opts ...Option) *PolicyEngine {
 //  4. Unsafe output redirect — there's already a write_file / edit
 //     tool that respects the workspace; the model should use that.
 //
-// In addition, shell-side read/discovery helpers (grep, sed -n, find, ls,
-// head, tail, cat, rg, and pipelines around them) are blocked with guidance to
-// the registered read/search/list tools. Expansion and Subshell flags are
+// In addition, shell-side read/discovery helpers (sed -n, find, ls, tail, cat,
+// and pipelines around them) are blocked with guidance to the registered
+// read/search/list tools. grep (and rg/head) are deliberately not in this set —
+// they are commonly used to filter real command output. Expansion and Subshell flags are
 // informational only; the agent is meant to be capable, not nannied.
 // In the relaxed profile the ergonomic `cd` and redirect blocks step aside
 // (the kernel sandbox is off; see PolicyEngine.relaxed). Shell read-tool
@@ -103,7 +104,7 @@ func (PolicyEngine) decide(ir ParsedIR, relaxed bool, blockReadTools bool) Decis
 
 	if blockReadTools && hasRisk(ir, ReasonShellReadTool) {
 		d.IsBlocked = true
-		d.BlockReason = "shell policy: use the registered workspace tools for file reading and discovery instead of shell grep/sed/find/ls/head/tail/cat or pipelines around them. " +
+		d.BlockReason = "shell policy: use the registered workspace tools for file reading and discovery instead of shell sed/find/ls/tail/cat or pipelines around them. " +
 			"Use `program`/`grep`/`read`/`ls`/`glob`/`file_map` for workspace files; reserve bash for builds, tests, package managers, git, servers, and other real processes."
 		return d
 	}

--- a/zkit/agent/shellpolicy/policy_test.go
+++ b/zkit/agent/shellpolicy/policy_test.go
@@ -100,7 +100,7 @@ func TestPolicy_DecisionEchoesReasonCodes(t *testing.T) {
 
 func TestPolicy_ShellReadToolsBlockWithGuidance(t *testing.T) {
 	t.Parallel()
-	for _, cmd := range []string{"grep -r foo .", "sed -n '1,20p' main.go", "find . -name '*.go'", "head -20 README.md"} {
+	for _, cmd := range []string{"cat main.go", "sed -n '1,20p' main.go", "find . -name '*.go'", "ls -la"} {
 		t.Run(cmd, func(t *testing.T) {
 			t.Parallel()
 			ir, _ := shellpolicy.NewUnixParser().Parse(cmd)
@@ -110,6 +110,21 @@ func TestPolicy_ShellReadToolsBlockWithGuidance(t *testing.T) {
 			}
 			if !strings.Contains(d.BlockReason, "registered workspace tools") {
 				t.Errorf("BlockReason = %q, want registered-tool guidance", d.BlockReason)
+			}
+		})
+	}
+}
+
+// grep and head are no longer shell read tools, so the policy lets them run —
+// including grep filtering the output of a real command.
+func TestPolicy_GrepAndHeadAllowed(t *testing.T) {
+	t.Parallel()
+	for _, cmd := range []string{"grep -r foo .", "head -20 README.md", "grep foo bar.txt"} {
+		t.Run(cmd, func(t *testing.T) {
+			t.Parallel()
+			ir, _ := shellpolicy.NewUnixParser().Parse(cmd)
+			if d := shellpolicy.NewPolicyEngine().Decide(ir); d.IsBlocked {
+				t.Errorf("Decide(%q): want allowed, blocked with %q", cmd, d.BlockReason)
 			}
 		})
 	}

--- a/zkit/agent/shellpolicy/unix.go
+++ b/zkit/agent/shellpolicy/unix.go
@@ -320,23 +320,21 @@ func interpreterReadsStdin(args []*syntax.Word, depth int) bool {
 // helpers that duplicate registered workspace tools. They are safe as shell
 // commands, but using them for repository discovery burns context and loses the
 // bounded, structured results the tools provide.
+//
+// The grep family (grep/egrep/fgrep/rg/ripgrep/ag) and head are intentionally
+// absent: grep is routinely used to filter the output of real commands
+// (`go test ./... | grep FAIL`, `git log | grep …`), and blocking it there is
+// pure friction rather than tool-routing, so shell grep and head are allowed.
 var shellReadTools = map[string]bool{
-	"ag":      true,
-	"awk":     true,
-	"cat":     true,
-	"egrep":   true,
-	"fd":      true,
-	"fgrep":   true,
-	"find":    true,
-	"grep":    true,
-	"head":    true,
-	"less":    true,
-	"ls":      true,
-	"more":    true,
-	"rg":      true,
-	"ripgrep": true,
-	"sed":     true,
-	"tail":    true,
+	"awk":  true,
+	"cat":  true,
+	"fd":   true,
+	"find": true,
+	"less": true,
+	"ls":   true,
+	"more": true,
+	"sed":  true,
+	"tail": true,
 }
 
 func callUsesShellReadTool(call *syntax.CallExpr) bool {

--- a/zkit/agent/shellpolicy/unix_test.go
+++ b/zkit/agent/shellpolicy/unix_test.go
@@ -97,7 +97,7 @@ func TestUnixParser_RisksTriggeredCorrectly(t *testing.T) {
 		{"pipe raises ReasonOperator", "ls | wc -l", shellpolicy.ReasonOperator},
 		{"&& raises ReasonOperator", "ls && pwd", shellpolicy.ReasonOperator},
 		{"semicolon between stmts raises ReasonOperator", "ls; pwd", shellpolicy.ReasonOperator},
-		{"grep raises ReasonShellReadTool", "grep -r foo .", shellpolicy.ReasonShellReadTool},
+		{"cat raises ReasonShellReadTool", "cat main.go", shellpolicy.ReasonShellReadTool},
 		{"sed raises ReasonShellReadTool", "sed -n '1,20p' main.go", shellpolicy.ReasonShellReadTool},
 		{"read-helper pipe raises ReasonShellReadTool", "ls | grep foo", shellpolicy.ReasonShellReadTool},
 		{"opaque interpreter pipe raises ReasonOpaqueInterpreter", "echo 'print(1)' | python3", shellpolicy.ReasonOpaqueInterpreter},
@@ -111,6 +111,24 @@ func TestUnixParser_RisksTriggeredCorrectly(t *testing.T) {
 			}
 			if !slices.Contains(ir.RiskFlags, tc.want) {
 				t.Errorf("RiskFlags = %v, want to contain %q", ir.RiskFlags, tc.want)
+			}
+		})
+	}
+}
+
+// grep (and its family) and head are no longer treated as shell read tools, so
+// bare or output-filtering uses don't raise ReasonShellReadTool.
+func TestUnixParser_GrepAndHeadAreNotReadTools(t *testing.T) {
+	t.Parallel()
+	for _, cmd := range []string{"grep -r foo .", "rg foo", "egrep foo x", "head -20 README.md"} {
+		t.Run(cmd, func(t *testing.T) {
+			t.Parallel()
+			ir, err := shellpolicy.NewUnixParser().Parse(cmd)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", cmd, err)
+			}
+			if slices.Contains(ir.RiskFlags, shellpolicy.ReasonShellReadTool) {
+				t.Errorf("%q raised ReasonShellReadTool, want it allowed", cmd)
 			}
 		})
 	}


### PR DESCRIPTION
The shell policy (`shellpolicy.shellReadTools`) treated the grep family (grep/egrep/fgrep/rg/ripgrep/ag) and `head` as read/discovery helpers that duplicate the registered workspace tools, and **blocked** them in bash with guidance to use the `grep`/`read`/`ls` tools instead.

That's wrong for grep specifically: grep is routinely used to filter the output of real commands — `go test ./... | grep FAIL`, `git log | grep …` — where blocking it is pure friction, not tool-routing. `head` has the same problem as a thin output trimmer.

## Change
- Remove `grep`, `egrep`, `fgrep`, `rg`, `ripgrep`, `ag`, and `head` from `shellReadTools` (`zkit/agent/shellpolicy/unix.go`).
- The rest stay steered toward the workspace tools: `cat`, `sed`, `find`, `ls`, `tail`, `awk`, `less`, `more`, `fd`.
- Updated the policy/IR doc comments and the block-reason text.

## Tests
- Reworked the existing block-list tests to use a still-steered command (`cat`/`sed`/`find`/`ls`).
- Added positive coverage: grep/rg/egrep/head no longer raise `ReasonShellReadTool`, the policy allows them, and the shell guardrail passes `grep -r TODO . | head -20`.
- `shellpolicy`, `guardrails`, `coderunner` suites green; vet + lint clean.