### PR TITLE
Keep replaced lines newline-terminated in hashline edit

### DIFF
--- a/zkit/ai/tools/code/hashline.go
+++ b/zkit/ai/tools/code/hashline.go
@@ -137,7 +137,7 @@ type HashlineEdit struct {
 	StartHash string `json:"start_hash" doc:"3- or 4-character base64 SHA-256 hash for start_line from the read output."`
 	EndLine   int    `json:"end_line,omitempty" doc:"Inclusive 1-based end line for replace/delete. Omit for a single-line edit."`
 	EndHash   string `json:"end_hash,omitempty" doc:"3- or 4-character base64 SHA-256 hash for end_line from the read output."`
-	NewString string `json:"new_string,omitempty" doc:"Replacement or insertion bytes. Include newline characters exactly as desired; use a single cohesive range edit when changing adjacent lines."`
+	NewString string `json:"new_string,omitempty" doc:"Replacement or insertion bytes. Include newline characters exactly as desired; a replace whose line already ended in a newline stays newline-terminated even if you omit the trailing newline. Use a single cohesive range edit when changing adjacent lines."`
 	Mode      string `json:"mode,omitempty" enum:"replace,delete,insert_before,insert_after" doc:"Edit mode: replace (default), delete, insert_before, or insert_after."`
 }
 
@@ -204,6 +204,7 @@ func (t *EditFileHLTool) Execute(_ context.Context, call tools.ToolCall) (*tools
 		return tools.Failure(call.ID, tools.Validation("edit", err.Error())), nil
 	}
 
+	preserveLineTerminators(body, resolved)
 	updated := applyResolvedHashlineEdits(body, resolved)
 	if err := t.ws.WriteFileInRoot(abs, []byte(updated), filesystem.ModePublicFile); err != nil {
 		return tools.Failure(call.ID, tools.Fatal("edit", fmt.Errorf("write %q: %w", args.Path, err))), nil
@@ -399,6 +400,32 @@ func validateResolvedHashlineEdits(path string, edits []resolvedHashlineEdit) er
 		}
 	}
 	return nil
+}
+
+// preserveLineTerminators keeps a replaced line range line-terminated. The edit
+// tool anchors on whole lines, so a replace whose spliced-out range ended in a
+// newline should stay newline-terminated. Models routinely omit the trailing
+// newline in new_string (and some providers drop a trailing newline while
+// streaming the argument), which would silently un-terminate the line — merging
+// it with the next one, or dropping the file's final newline. When the removed
+// range ended in "\n" but the replacement doesn't, re-append it (matching the
+// original CRLF/LF terminator). Deletes (empty replacement) and inserts
+// (zero-width splice) are unaffected by construction.
+func preserveLineTerminators(body string, edits []resolvedHashlineEdit) {
+	for i := range edits {
+		e := &edits[i]
+		if e.SpliceEnd <= e.SpliceStart || e.Replacement == "" {
+			continue
+		}
+		if body[e.SpliceEnd-1] != '\n' || strings.HasSuffix(e.Replacement, "\n") {
+			continue
+		}
+		if e.SpliceEnd >= 2 && body[e.SpliceEnd-2] == '\r' {
+			e.Replacement += "\r\n"
+			continue
+		}
+		e.Replacement += "\n"
+	}
 }
 
 func applyResolvedHashlineEdits(body string, edits []resolvedHashlineEdit) string {

--- a/zkit/ai/tools/code/hashline_test.go
+++ b/zkit/ai/tools/code/hashline_test.go
@@ -145,6 +145,75 @@ func TestEditFileHLTool_BatchRejectsStaleWithoutWriting(t *testing.T) {
 	}
 }
 
+// A replace whose original line ended in a newline stays newline-terminated
+// even when new_string omits the trailing newline — the tool must not
+// silently un-terminate the line or drop the file's final newline.
+func TestEditFileHLTool_PreservesTrailingNewline(t *testing.T) {
+	t.Parallel()
+	ws, root := mustWS(t)
+	path := filepath.Join(root, "nl.txt")
+
+	// Replace a middle line without a trailing newline: must not merge lines.
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+		Path:  "nl.txt",
+		Edits: []code.HashlineEdit{{StartLine: 2, StartHash: testHashlineHash("two", 4), NewString: "TWO"}},
+	})
+	if !res.Success {
+		t.Fatalf("edit failed: %s", res.Error)
+	}
+	if got := readFile(t, path); got != "one\nTWO\nthree\n" {
+		t.Fatalf("mid-line replace = %q, want newline preserved", got)
+	}
+
+	// Replace the last line without a trailing newline: file keeps its final \n.
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res = execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+		Path:  "nl.txt",
+		Edits: []code.HashlineEdit{{StartLine: 3, StartHash: testHashlineHash("three", 4), NewString: "THREE"}},
+	})
+	if !res.Success {
+		t.Fatalf("edit failed: %s", res.Error)
+	}
+	if got := readFile(t, path); got != "one\ntwo\nTHREE\n" {
+		t.Fatalf("last-line replace = %q, want trailing newline preserved", got)
+	}
+
+	// A file with no final newline stays that way (nothing to preserve).
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res = execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+		Path:  "nl.txt",
+		Edits: []code.HashlineEdit{{StartLine: 3, StartHash: testHashlineHash("three", 4), NewString: "THREE"}},
+	})
+	if !res.Success {
+		t.Fatalf("edit failed: %s", res.Error)
+	}
+	if got := readFile(t, path); got != "one\ntwo\nTHREE" {
+		t.Fatalf("no-EOL file replace = %q, want no trailing newline added", got)
+	}
+
+	// An explicit trailing newline in new_string is not doubled.
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res = execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+		Path:  "nl.txt",
+		Edits: []code.HashlineEdit{{StartLine: 2, StartHash: testHashlineHash("two", 4), NewString: "TWO\n"}},
+	})
+	if !res.Success {
+		t.Fatalf("edit failed: %s", res.Error)
+	}
+	if got := readFile(t, path); got != "one\nTWO\nthree\n" {
+		t.Fatalf("explicit newline = %q, want single newline", got)
+	}
+}
+
 func TestEditFileHLTool_ReturnsFreshAnchorWindow(t *testing.T) {
 	t.Parallel()
 	ws, root := mustWS(t)


### PR DESCRIPTION
## Symptom
`new_string` in the edit tool kept dropping the trailing newline — edits would silently un-terminate a line.

## Root cause
I reproduced it end to end. The edit tool, the repair JSON parser, and arg canonicalization all preserve `new_string` **verbatim** — the trailing newline is dropped because it isn't in `new_string` by the time it's applied (the model omits it, or a provider drops it while streaming the argument). Concretely: replacing the last line `three\n` with `new_string="THREE"` produced `…\nTHREE` (no final newline); replacing a middle line without a trailing newline merged it with the next.

## Fix
The tool anchors on **whole lines**, so a replace whose spliced-out range ended in a newline should stay newline-terminated. `preserveLineTerminators` re-appends the original terminator (LF or CRLF) when the removed range ended in `\n` but `new_string` doesn't. This is robust regardless of *why* the newline went missing.

- Deletes (empty replacement) and inserts (zero-width splice) are unaffected by construction.
- A file with no final newline is left as-is (nothing to preserve).
- An explicit trailing newline in `new_string` is not doubled.

## Tests
`TestEditFileHLTool_PreservesTrailingNewline` covers mid-line replace, last-line replace, no-final-newline file, and explicit-newline (no doubling). Full `code` package green; vet + lint clean.