### PR TITLE
Cache the anthropic static prefix with a 1-hour TTL

### DIFF
--- a/zkit/ai/llm/anthropic/convert_internal_test.go
+++ b/zkit/ai/llm/anthropic/convert_internal_test.go
@@ -160,3 +160,25 @@ func TestSetLastMessageCacheBreakpoint_NoOpOnEmpty(t *testing.T) {
 	setLastMessageCacheBreakpoint(nil)
 	setLastMessageCacheBreakpoint([]anthropic.MessageParam{})
 }
+
+// The static prefix (system/tools) uses the 1-hour TTL so it survives idle
+// gaps, while the rolling last-message breakpoint keeps the default 5-minute
+// TTL — its tail is superseded each turn, so a 1-hour write there would waste
+// the 2x multiplier.
+func TestCacheTTLs_StaticIs1hRollingIsDefault(t *testing.T) {
+	if got := staticCacheControl().TTL; got != anthropic.CacheControlEphemeralTTLTTL1h {
+		t.Fatalf("static prefix TTL = %q, want 1h", got)
+	}
+
+	out := convertMessagesToSDK([]llm.Message{
+		{Role: llm.RoleUser, Content: "hi"},
+	})
+	setLastMessageCacheBreakpoint(out)
+	cc := out[len(out)-1].Content[0].GetCacheControl()
+	if cc == nil {
+		t.Fatal("rolling breakpoint not set")
+	}
+	if cc.TTL != "" {
+		t.Fatalf("rolling breakpoint TTL = %q, want default (empty = 5m)", cc.TTL)
+	}
+}

--- a/zkit/ai/llm/anthropic/provider.go
+++ b/zkit/ai/llm/anthropic/provider.go
@@ -104,18 +104,19 @@ func (p *Provider) streamCompletion(ctx context.Context, req llm.CompletionReque
 		params.Temperature = anthropic.Float(float64(req.Temperature))
 	}
 
-	// Add system prompt if present. Mark with cache_control:ephemeral
-	// so Anthropic serves the (typically multi-kilobyte) system
-	// prompt from its KV cache on subsequent turns, saving prompt
-	// tokens on every iteration within a 5-minute window. The cost
-	// of a cache write is ~25% extra on the first request; the
-	// payoff is ~90% off on every cached read after that.
+	// Add system prompt if present. Mark with cache_control:ephemeral so
+	// Anthropic serves the (typically multi-kilobyte) system prompt — and the
+	// tools that precede it in the cache prefix — from its KV cache on
+	// subsequent turns. The static prefix uses the 1-hour TTL (see
+	// staticCacheControl): a cache read is ~90% off, and the extra write cost
+	// buys survival across the multi-minute idle gaps between turns that would
+	// otherwise evict the default 5-minute cache and force a full re-warm.
 	systemPrompt := extractSystemPrompt(req.Messages)
 	if systemPrompt != "" {
 		params.System = []anthropic.TextBlockParam{
 			{
 				Text:         systemPrompt,
-				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+				CacheControl: staticCacheControl(),
 			},
 		}
 	}
@@ -302,14 +303,14 @@ func (p *Provider) nonStreamCompletion(ctx context.Context, req llm.CompletionRe
 		params.Temperature = anthropic.Float(float64(req.Temperature))
 	}
 
-	// Add system prompt if present, marked for ephemeral caching
-	// (see streaming path for rationale).
+	// Add system prompt if present, marked for 1-hour ephemeral caching
+	// (see streaming path + staticCacheControl for rationale).
 	systemPrompt := extractSystemPrompt(req.Messages)
 	if systemPrompt != "" {
 		params.System = []anthropic.TextBlockParam{
 			{
 				Text:         systemPrompt,
-				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+				CacheControl: staticCacheControl(),
 			},
 		}
 	}
@@ -509,6 +510,21 @@ func convertMessagesToSDK(messages []llm.Message) []anthropic.MessageParam {
 // Safe on any conversation: an empty message list or a block type that can't
 // carry cache_control is a no-op, and a prefix shorter than the model's
 // minimum cacheable length is silently ignored by the API rather than erroring.
+// staticCacheControl marks the static prefix (tools + system) with a 1-hour
+// cache TTL rather than the default 5 minutes. That prefix is identical for a
+// whole session, so it is written once and read on every turn; the 1-hour TTL
+// lets it survive the multi-minute idle gaps between turns (user think-time,
+// tool-approval waits) that would otherwise evict the 5-minute cache and force
+// a full re-warm. The extra write cost (2x base vs 1.25x) is paid on that
+// one-time write; every read stays ~90% off. The rolling last-message
+// breakpoint keeps the cheaper 5-minute default because its tail is superseded
+// each turn — a 1-hour write there would pay 2x for content used briefly.
+func staticCacheControl() anthropic.CacheControlEphemeralParam {
+	cc := anthropic.NewCacheControlEphemeralParam()
+	cc.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+	return cc
+}
+
 func setLastMessageCacheBreakpoint(messages []anthropic.MessageParam) {
 	if len(messages) == 0 {
 		return


### PR DESCRIPTION
Follow-up to the conversation-prefix caching, informed by Anthropic's caching docs and the mempko/openclaw cache-eviction analyses.

## Problem
The default prompt-cache TTL is 5 minutes (sliding — refreshed free on each hit). That keeps an *active* session warm, but a multi-minute idle gap between turns (user think-time, tool-approval waits) evicts the cache. On resume the whole tools+system+history prefix is re-cached at **write** pricing — the ~10× cache-miss cost.

## Change
Mark the **static prefix** (system, which caches tools+system ahead of it) with `cache_control: {ttl: "1h"}` via a new `staticCacheControl()` helper, applied in both the streaming and non-streaming paths.

- The static prefix is identical for a whole session, so the 1-hour TTL is written once and read on every turn — it survives normal idle gaps with no keepalive machinery.
- Write cost 2× (vs 1.25×) is paid only on that one-time write; reads stay ~90% off.
- The **rolling last-message breakpoint keeps the 5-minute default** — its tail is superseded each turn, so a 1-hour write there would waste the 2× multiplier.

## Not included (follow-up)
This covers the static prefix. Keeping the *growing conversation history* warm across idle needs a cost-capped keep-warm ping (openclaw #62475's design: `max_tokens:1` at ~80% TTL, `$/hr` cap with auto-disable, dirty-flag on prompt change). Speccing that separately.

## Tests
`TestCacheTTLs_StaticIs1hRollingIsDefault` asserts the static breakpoint is 1h and the rolling one stays default. Full anthropic suite green; vet + lint clean.