### PR TITLE
Keep hashline inserts on their own lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [zarlcode/v0.6.2] — 2026-07-23
+`zarlcode/v0.6.2`
+
+### Changed
+
+- Picks up zkit v0.5.2: the hashline `edit` tool no longer merges inserted text into a neighbouring line, and no longer shreds a range edit that shares its start with an insert.
+
+## [zkit/v0.5.2] — 2026-07-23
+`zkit/v0.5.2`
+
+### Fixed
+
+- The hashline `edit` tool keeps inserted text on lines of its own. An insert splices zero bytes, so — unlike a replace — it borrows no line terminator from what it displaces: an `insert_before`/`insert_after` whose `new_string` omitted the trailing newline fused onto the following line, and an `insert_after` on a final line with no newline fused onto the anchor line. The terminator now matches the file's own LF/CRLF, and a file with no final newline stays that way. This is the case v0.5.1 recorded as unaffected.
+- A batch `edit` no longer corrupts a range edit that resolves to the same splice start as an insert (`insert_before` on the first line of a replaced range). Splices run from the tail, and the insert could go down first, shifting the bytes under the range's end offset so that splice landed mid-file — dropping the inserted text and resurrecting part of the replaced range. The wider range is now applied first. The fresh-anchor window returned by `edit` takes the same ordering, so it no longer reports shifted line numbers for that case.
+
 ## [zarlcode/v0.6.1] — 2026-07-22
 `zarlcode/v0.6.1`
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -593,6 +593,7 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.135.0/go.mod h1:VYUUkRJkKuQPkIpgtZJj6+5
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zarldev/zarlmono/zkit v0.4.0/go.mod h1:qGJQ8/ZIAnIe4byY6asorUqt8Dt8lOlQYs0pWT+u+70=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=

--- a/zkit/ai/tools/code/hashline.go
+++ b/zkit/ai/tools/code/hashline.go
@@ -137,7 +137,7 @@ type HashlineEdit struct {
 	StartHash string `json:"start_hash" doc:"3- or 4-character base64 SHA-256 hash for start_line from the read output."`
 	EndLine   int    `json:"end_line,omitempty" doc:"Inclusive 1-based end line for replace/delete. Omit for a single-line edit."`
 	EndHash   string `json:"end_hash,omitempty" doc:"3- or 4-character base64 SHA-256 hash for end_line from the read output."`
-	NewString string `json:"new_string,omitempty" doc:"Replacement or insertion bytes. Include newline characters exactly as desired; a replace whose line already ended in a newline stays newline-terminated even if you omit the trailing newline. Use a single cohesive range edit when changing adjacent lines."`
+	NewString string `json:"new_string,omitempty" doc:"Replacement or insertion bytes. Include newline characters exactly as desired; edits are line-anchored, so text stays on lines of its own even if you omit the trailing newline. Use a single cohesive range edit when changing adjacent lines."`
 	Mode      string `json:"mode,omitempty" enum:"replace,delete,insert_before,insert_after" doc:"Edit mode: replace (default), delete, insert_before, or insert_after."`
 }
 
@@ -402,37 +402,86 @@ func validateResolvedHashlineEdits(path string, edits []resolvedHashlineEdit) er
 	return nil
 }
 
-// preserveLineTerminators keeps a replaced line range line-terminated. The edit
-// tool anchors on whole lines, so a replace whose spliced-out range ended in a
-// newline should stay newline-terminated. Models routinely omit the trailing
-// newline in new_string (and some providers drop a trailing newline while
-// streaming the argument), which would silently un-terminate the line — merging
-// it with the next one, or dropping the file's final newline. When the removed
-// range ended in "\n" but the replacement doesn't, re-append it (matching the
-// original CRLF/LF terminator). Deletes (empty replacement) and inserts
-// (zero-width splice) are unaffected by construction.
+// preserveLineTerminators keeps every edited region line-terminated. The edit
+// tool anchors on whole lines, so no edit may fuse its text onto a neighbouring
+// line. Models routinely omit the trailing newline in new_string (and some
+// providers drop one while streaming the argument), which would silently
+// un-terminate the line — merging it with the next one, or dropping the file's
+// final newline.
+//
+// Replace: when the spliced-out range ended in "\n" but the replacement
+// doesn't, re-append it. Insert: see preserveInsertTerminators — a zero-width
+// splice inherits no terminator at all, so both sides need checking. Deletes
+// (empty replacement) are unaffected by construction.
 func preserveLineTerminators(body string, edits []resolvedHashlineEdit) {
 	for i := range edits {
 		e := &edits[i]
-		if e.SpliceEnd <= e.SpliceStart || e.Replacement == "" {
+		if e.Replacement == "" {
+			continue
+		}
+		if e.SpliceEnd == e.SpliceStart {
+			preserveInsertTerminators(body, e)
 			continue
 		}
 		if body[e.SpliceEnd-1] != '\n' || strings.HasSuffix(e.Replacement, "\n") {
 			continue
 		}
-		if e.SpliceEnd >= 2 && body[e.SpliceEnd-2] == '\r' {
-			e.Replacement += "\r\n"
-			continue
-		}
-		e.Replacement += "\n"
+		e.Replacement += hashlineEOL(body, e.SpliceEnd)
 	}
 }
 
+// preserveInsertTerminators keeps an inserted block on lines of its own. An
+// insert splices zero bytes, so it borrows no terminator from what it displaces
+// and merges with whatever it lands against: a new_string without a trailing
+// newline fuses onto the following line, and insert_after on a final line that
+// has no newline fuses onto the anchor line itself. A newline goes in front
+// whenever the splice point isn't already at a line boundary, and behind unless
+// the insert appends to a file that never had a final newline — there, staying
+// unterminated preserves the file's existing shape.
+func preserveInsertTerminators(body string, e *resolvedHashlineEdit) {
+	at := e.SpliceStart
+	eol := hashlineEOL(body, at)
+	if at > 0 && body[at-1] != '\n' {
+		e.Replacement = eol + e.Replacement
+	}
+	if strings.HasSuffix(e.Replacement, "\n") {
+		return
+	}
+	if at < len(body) || strings.HasSuffix(body, "\n") {
+		e.Replacement += eol
+	}
+}
+
+// hashlineEOL reports the line terminator in use around byte offset off:
+// "\r\n" when the nearest newline behind (then ahead of) off is the tail of a
+// CRLF pair, "\n" otherwise. Used so a terminator this package adds matches
+// the file it is added to.
+func hashlineEOL(body string, off int) string {
+	if i := strings.LastIndexByte(body[:off], '\n'); i > 0 && body[i-1] == '\r' {
+		return "\r\n"
+	}
+	if i := strings.IndexByte(body[off:], '\n'); i > 0 && body[off+i-1] == '\r' {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// applyResolvedHashlineEdits splices every edit into body from the tail
+// forwards, so each splice's byte offsets are still valid when it runs.
+//
+// The tie-breaks matter. An insert may share a splice start with the replace
+// or delete it sits in front of; the wider range must go first, or the insert
+// shifts the bytes under the range's end offset and the range splice lands
+// mid-file. Among edits at one zero-width point, descending index puts the
+// last-listed text down first, leaving the model's array order in the file.
 func applyResolvedHashlineEdits(body string, edits []resolvedHashlineEdit) string {
 	sorted := slices.Clone(edits)
 	slices.SortFunc(sorted, func(a, b resolvedHashlineEdit) int {
 		if a.SpliceStart != b.SpliceStart {
 			return b.SpliceStart - a.SpliceStart
+		}
+		if a.SpliceEnd != b.SpliceEnd {
+			return b.SpliceEnd - a.SpliceEnd
 		}
 		return b.Index - a.Index
 	})
@@ -456,14 +505,18 @@ func hashlineEditWindows(updated string, edits []resolvedHashlineEdit) string {
 		return ""
 	}
 
-	// New byte position of each replacement, ascending by original splice,
-	// accumulating the length delta of all earlier edits. This mirrors
-	// applyResolvedHashlineEdits, which splices from the tail so an earlier
-	// edit's prefix is never disturbed by a later one.
+	// New byte position of each replacement, accumulating the length delta of
+	// all earlier edits. The order is applyResolvedHashlineEdits' order
+	// reversed — that function splices from the tail, so reversing it walks
+	// the replacements in the order they lie in the file, which is what makes
+	// a running delta correct.
 	sorted := slices.Clone(edits)
 	slices.SortFunc(sorted, func(a, b resolvedHashlineEdit) int {
 		if a.SpliceStart != b.SpliceStart {
 			return a.SpliceStart - b.SpliceStart
+		}
+		if a.SpliceEnd != b.SpliceEnd {
+			return a.SpliceEnd - b.SpliceEnd
 		}
 		return a.Index - b.Index
 	})

--- a/zkit/ai/tools/code/hashline_test.go
+++ b/zkit/ai/tools/code/hashline_test.go
@@ -214,6 +214,131 @@ func TestEditFileHLTool_PreservesTrailingNewline(t *testing.T) {
 	}
 }
 
+// An insert splices zero bytes, so it borrows no line terminator from what it
+// displaces: without help it fuses onto the line after it (new_string with no
+// trailing newline) or the line before it (insert_after on an unterminated
+// final line).
+func TestEditFileHLTool_InsertsStayOnTheirOwnLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		seed string
+		edit code.HashlineEdit
+		want string
+	}{
+		{
+			name: "insert_after without trailing newline",
+			seed: "one\ntwo\nthree\n",
+			edit: code.HashlineEdit{StartLine: 1, StartHash: testHashlineHash("one", 4), Mode: "insert_after", NewString: "NEW"},
+			want: "one\nNEW\ntwo\nthree\n",
+		},
+		{
+			name: "insert_before without trailing newline",
+			seed: "one\ntwo\nthree\n",
+			edit: code.HashlineEdit{StartLine: 2, StartHash: testHashlineHash("two", 4), Mode: "insert_before", NewString: "NEW"},
+			want: "one\nNEW\ntwo\nthree\n",
+		},
+		{
+			name: "insert_after an unterminated final line",
+			seed: "one\ntwo\nthree",
+			edit: code.HashlineEdit{StartLine: 3, StartHash: testHashlineHash("three", 4), Mode: "insert_after", NewString: "NEW\n"},
+			want: "one\ntwo\nthree\nNEW\n",
+		},
+		{
+			name: "insert at end of an unterminated file stays unterminated",
+			seed: "one\ntwo\nthree",
+			edit: code.HashlineEdit{StartLine: 3, StartHash: testHashlineHash("three", 4), Mode: "insert_after", NewString: "NEW"},
+			want: "one\ntwo\nthree\nNEW",
+		},
+		{
+			name: "insert at end of a terminated file stays terminated",
+			seed: "one\ntwo\n",
+			edit: code.HashlineEdit{StartLine: 2, StartHash: testHashlineHash("two", 4), Mode: "insert_after", NewString: "NEW"},
+			want: "one\ntwo\nNEW\n",
+		},
+		{
+			name: "explicit newline is not doubled",
+			seed: "one\ntwo\n",
+			edit: code.HashlineEdit{StartLine: 1, StartHash: testHashlineHash("one", 4), Mode: "insert_after", NewString: "NEW\n"},
+			want: "one\nNEW\ntwo\n",
+		},
+		{
+			name: "multi-line insert terminates only the last line",
+			seed: "one\ntwo\n",
+			edit: code.HashlineEdit{StartLine: 1, StartHash: testHashlineHash("one", 4), Mode: "insert_after", NewString: "A\nB"},
+			want: "one\nA\nB\ntwo\n",
+		},
+		{
+			name: "CRLF file gets a CRLF terminator",
+			seed: "one\r\ntwo\r\n",
+			edit: code.HashlineEdit{StartLine: 1, StartHash: testHashlineHash("one", 4), Mode: "insert_after", NewString: "NEW"},
+			want: "one\r\nNEW\r\ntwo\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ws, root := mustWS(t)
+			path := filepath.Join(root, "ins.txt")
+			if err := os.WriteFile(path, []byte(tt.seed), 0o644); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			res := execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+				Path:  "ins.txt",
+				Edits: []code.HashlineEdit{tt.edit},
+			})
+			if !res.Success {
+				t.Fatalf("edit failed: %s", res.Error)
+			}
+			if got := readFile(t, path); got != tt.want {
+				t.Fatalf("content = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// An insert and a replace can resolve to the same splice start. Splicing runs
+// from the tail, so the wider range must go first — otherwise the insert
+// shifts the bytes under the replace's end offset and that splice lands
+// mid-file, shredding the region instead of replacing it.
+func TestEditFileHLTool_InsertSharingASpliceStartWithARange(t *testing.T) {
+	t.Parallel()
+	ws, root := mustWS(t)
+	path := filepath.Join(root, "shared-start.txt")
+
+	// The insert is listed second, so it is also the later index — the case
+	// where a descending-index tie-break alone would apply it first.
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := execTyped(t, code.NewEditFileHLTool(ws), code.EditFileHLArgs{
+		Path: "shared-start.txt",
+		Edits: []code.HashlineEdit{
+			{
+				StartLine: 2,
+				StartHash: testHashlineHash("two", 4),
+				EndLine:   3,
+				EndHash:   testHashlineHash("three", 4),
+				NewString: "TWO-THREE\n",
+			},
+			{
+				StartLine: 2,
+				StartHash: testHashlineHash("two", 4),
+				Mode:      "insert_before",
+				NewString: "HEADER\n",
+			},
+		},
+	})
+	if !res.Success {
+		t.Fatalf("edit failed: %s", res.Error)
+	}
+	if got := readFile(t, path); got != "one\nHEADER\nTWO-THREE\nfour\n" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
 func TestEditFileHLTool_ReturnsFreshAnchorWindow(t *testing.T) {
 	t.Parallel()
 	ws, root := mustWS(t)


### PR DESCRIPTION
The hashline `edit` tool merged inserted text into neighbouring lines, and could shred a range edit that shared its splice start with an insert.

### Inserts

`preserveLineTerminators` only guarded the replace path — its comment claimed inserts were "unaffected by construction". A replace inherits a terminator from the bytes it displaces; an insert splices zero bytes and so inherits none.

| input | before | after |
|---|---|---|
| `insert_after`/`insert_before`, no trailing `\n` | `one\nINSERTEDtwo\n` | `one\nINSERTED\ntwo\n` |
| `insert_after` on a final line with no newline | `one\nthreeINSERTED\n` | `one\nthree\nINSERTED\n` |

Models omit the trailing newline constantly (and some providers drop it while streaming the argument), so this fired often, and silently — the write succeeds and the result reports success.

The added terminator matches the file's own LF/CRLF, and a file with no final newline is left unterminated.

### Batch ordering

An insert can resolve to the same `SpliceStart` as the range edit it sits in front of. Splices run from the tail, and the tie-break was descending index, so a later-listed insert could go down first and shift the bytes under the range's end offset — that splice then landed mid-file:

```
replace lines 2-3 + insert_before line 2
  before: "one\nTWO-THREE\n\nthree\nfour\n"   <- inserted text dropped, "three" resurrected
  after:  "one\nHEADER\nTWO-THREE\nfour\n"
```

The wider range now goes first. `hashlineEditWindows` gets the mirrored ascending tie-break, since its running delta must walk edits in the order they lie in the file — otherwise it handed back shifted anchors for the same case.

Regression tests cover both, plus CRLF, multi-line inserts, and the unterminated-file shapes. `task check`, `task lint`, and `task race` pass.