### PR TITLE
Point zarlcode at zkit v0.5.2

### DIFF
--- a/go.work
+++ b/go.work
@@ -9,4 +9,4 @@ use (
 	./zkit
 )
 
-replace github.com/zarldev/zarlmono/zkit v0.5.1 => ./zkit
+replace github.com/zarldev/zarlmono/zkit v0.5.2 => ./zkit

--- a/zarlcode/go.mod
+++ b/zarlcode/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
-	github.com/zarldev/zarlmono/zkit v0.5.1
+	github.com/zarldev/zarlmono/zkit v0.5.2
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
Wires zarlcode to the just-tagged zkit v0.5.2, which keeps hashline `edit` inserts on their own lines and fixes the batch-edit ordering bug where an insert sharing a splice start with a range edit corrupted the range. Changelog for zarlcode v0.6.2 landed in #30.