### PR TITLE
Add shell-policy off mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [zarlcode/v0.6.3] — 2026-07-24
+`zarlcode/v0.6.3`
+
+### Added
+
+- Shell policy gains an `off` mode: it drops the static shell guardrail from the chain entirely, so no bash command is parsed or blocked. A deliberate high-trust opt-in beyond `lenient`, which keeps the guardrail and only steps aside the ergonomic `cd`/redirect steers.
+
+### Changed
+
+- Picks up zkit v0.5.3 for the exported `NameShellPolicy` guardrail handle.
+
+## [zkit/v0.5.3] — 2026-07-24
+`zkit/v0.5.3`
+
+### Added
+
+- Exported the `NameShellPolicy` guardrail name constant, and `ShellGuardrail.Name()` now returns it, so consumers can drop the static shell guardrail via `Deps.Disabled` without a hardcoded string — matching `NameImprovementLoop`/`NameSkillHint`.
+
 ## [zarlcode/v0.6.2] — 2026-07-23
 `zarlcode/v0.6.2`
 

--- a/zarlcode/engine/guardrail_deps_internal_test.go
+++ b/zarlcode/engine/guardrail_deps_internal_test.go
@@ -141,6 +141,18 @@ func TestShellGuardLenientModes(t *testing.T) {
 	if !live.guardrailDeps().ShellLenient {
 		t.Fatal("lenient pin → want ShellLenient true regardless of sandbox")
 	}
+	// off: the guardrail is dropped from the chain entirely, not merely
+	// relaxed — Disabled carries its name regardless of the sandbox state.
+	setGuard("off")
+	setSandbox("on")
+	if d := live.guardrailDeps().Disabled; !slices.Contains(d, guardrails.NameShellPolicy) {
+		t.Fatalf("off → Disabled = %v, want to contain %q", d, guardrails.NameShellPolicy)
+	}
+	// Any non-off mode leaves the guardrail in the chain.
+	setGuard("lenient")
+	if d := live.guardrailDeps().Disabled; slices.Contains(d, guardrails.NameShellPolicy) {
+		t.Fatalf("lenient → Disabled = %v, want not to contain %q", d, guardrails.NameShellPolicy)
+	}
 }
 
 func TestZarlcodeGuardrailDepsDoNotDefaultLoadGoVerifier(t *testing.T) {

--- a/zarlcode/engine/live.go
+++ b/zarlcode/engine/live.go
@@ -640,6 +640,12 @@ func (l *LiveRunner) guardrailDepsFor(headless bool) guardrails.Deps {
 		deps.ShellLenient = l.settings.ShellGuardLenient(l.parentContext(), sandboxOn)
 		// Always-on guardrails the user can drop from the chain. Names come
 		// from the guardrails package so they can't drift from Name().
+		if l.settings.ShellGuardOff(l.parentContext()) {
+			// "off" removes the shell guardrail outright — a high-trust opt-in
+			// beyond "lenient" (which keeps it and only relaxes the steers).
+			// ShellLenient is then moot since the guardrail is gone.
+			deps.Disabled = append(deps.Disabled, guardrails.NameShellPolicy)
+		}
 		if !l.settings.ImprovementGuard(l.parentContext()) {
 			deps.Disabled = append(deps.Disabled, guardrails.NameImprovementLoop)
 		}

--- a/zarlcode/engine/settings.go
+++ b/zarlcode/engine/settings.go
@@ -284,15 +284,39 @@ func (s *Settings) SkillHints(ctx context.Context) bool {
 	return s.setting(ctx, prefs.KeySkillHints, "on") == "on"
 }
 
+// Shell-policy mode strings for KeyShellGuard.
+const (
+	shellGuardLenient = "lenient"
+	shellGuardOff     = "off"
+)
+
+// shellGuardMode returns the normalised KeyShellGuard value: "auto" (default),
+// "strict", "lenient", or "off".
+func (s *Settings) shellGuardMode(ctx context.Context) string {
+	return strings.ToLower(strings.TrimSpace(s.setting(ctx, prefs.KeyShellGuard, "auto")))
+}
+
+// ShellGuardOff reports whether the static shell policy is switched off
+// entirely — the guardrail is dropped from the chain, so no bash command is
+// parsed or blocked (the verify-mode write-target blocks included). This is a
+// deliberate high-trust opt-in, distinct from "lenient": lenient keeps the
+// guardrail and only steps aside the ergonomic cd/redirect steers, while off
+// removes the guardrail outright. live.go maps it to Deps.Disabled.
+func (s *Settings) ShellGuardOff(ctx context.Context) bool {
+	return s.shellGuardMode(ctx) == shellGuardOff
+}
+
 // ShellGuardLenient resolves the shell policy's leniency for the given sandbox
 // state. "auto" (default) follows the sandbox — lenient only when it is off;
-// "strict" and "lenient" pin the choice regardless. Kept as a resolver (rather
-// than a bare mode) so the sandbox-follows default lives in one place.
+// "strict" and "lenient" pin the choice regardless. "off" is moot here (the
+// guardrail is dropped via ShellGuardOff before this is consulted) and falls to
+// the auto branch. Kept as a resolver (rather than a bare mode) so the
+// sandbox-follows default lives in one place.
 func (s *Settings) ShellGuardLenient(ctx context.Context, sandboxOn bool) bool {
-	switch strings.ToLower(strings.TrimSpace(s.setting(ctx, prefs.KeyShellGuard, "auto"))) {
+	switch s.shellGuardMode(ctx) {
 	case guardModeStrict:
 		return false
-	case "lenient":
+	case shellGuardLenient:
 		return true
 	default:
 		return !sandboxOn

--- a/zarlcode/tui/settings_dialog.go
+++ b/zarlcode/tui/settings_dialog.go
@@ -228,8 +228,8 @@ func newSettingsDialogWithContext(ctx context.Context, s *engine.Settings) *sett
 					desc: "keep the agent working while its verifiers still report failure instead of stopping early. off removes the guardrail from the chain."},
 				{label: "skill hints", key: prefs.KeySkillHints, kind: rowEnum, def: "on", opts: []string{"on", "off"},
 					desc: "suggest a recovery skill after a tool call keeps failing. off removes the guardrail from the chain."},
-				{label: "shell policy", key: prefs.KeyShellGuard, kind: rowEnum, def: "auto", opts: []string{"auto", "strict", "lenient"},
-					desc: "static shell-command guardrail leniency. auto follows the sandbox (strict when on, lenient when off); strict/lenient pin it regardless of the sandbox."},
+				{label: "shell policy", key: prefs.KeyShellGuard, kind: rowEnum, def: "auto", opts: []string{"auto", "strict", "lenient", "off"},
+					desc: "static shell-command guardrail leniency. auto follows the sandbox (strict when on, lenient when off); strict/lenient pin it regardless of the sandbox; off removes the guardrail from the chain entirely."},
 			}},
 			{name: "compaction", rows: []settingsRow{
 				{label: "mode", key: prefs.KeyCompactionMode, kind: rowEnum, def: "auto", opts: []string{"auto", "manual"},

--- a/zkit/agent/guardrails/composition.go
+++ b/zkit/agent/guardrails/composition.go
@@ -73,6 +73,7 @@ type Deps struct {
 const (
 	NameImprovementLoop = "improvement_loop"
 	NameSkillHint       = "skill_hint"
+	NameShellPolicy     = "shell_policy"
 )
 
 // PostSchemaGuardrails returns the production guardrails that compose after

--- a/zkit/agent/guardrails/shell_guardrail.go
+++ b/zkit/agent/guardrails/shell_guardrail.go
@@ -67,8 +67,9 @@ func WithShellLenient(lenient bool) options.Option[ShellGuardrail] {
 }
 
 // Name returns the guardrail's identifier — surfaces in the failed
-// ToolResult's Error string as `guardrail "shell_policy": …`.
-func (g *ShellGuardrail) Name() string { return "shell_policy" }
+// ToolResult's Error string as `guardrail "shell_policy": …`, and is the
+// handle the Disabled knob drops it by.
+func (g *ShellGuardrail) Name() string { return NameShellPolicy }
 
 // Before parses call.Arguments["command"] (when the call targets
 // the configured shell tool) and returns a tools.Validation error

--- a/zkit/prefs/keys.go
+++ b/zkit/prefs/keys.go
@@ -47,9 +47,11 @@ const (
 	// KeySkillHints toggles the skill-hint guardrail, which suggests a recovery
 	// skill after a tool call keeps failing. "on" default.
 	KeySkillHints = "skill_hints"
-	// KeyShellGuard controls the static shell policy's leniency. "auto" (default)
-	// follows the sandbox setting — strict when the sandbox is on, lenient when
-	// off; "strict" and "lenient" pin the choice regardless of the sandbox.
+	// KeyShellGuard controls the static shell policy. "auto" (default) follows
+	// the sandbox setting — strict when the sandbox is on, lenient when off;
+	// "strict" and "lenient" pin the leniency regardless of the sandbox; "off"
+	// drops the shell guardrail from the chain entirely (no bash command is
+	// parsed or blocked).
 	KeyShellGuard = "shell_guard"
 	// KeyTemperature sets the sampling temperature on completion requests.
 	// Empty/"(default)" leaves it unset (server default). A low value (e.g. 0.2)


### PR DESCRIPTION
Adds an `off` mode to the shell-policy setting, alongside `auto`/`strict`/`lenient`.

Where `lenient` keeps the static shell guardrail in the chain and only relaxes the ergonomic `cd`/redirect steers, `off` removes the guardrail from the chain entirely — no bash command is parsed or blocked. A deliberate high-trust opt-in.

## zkit (v0.5.3)
- Export `NameShellPolicy` guardrail-name constant; `ShellGuardrail.Name()` returns it, matching `NameImprovementLoop`/`NameSkillHint`.

## zarlcode (v0.6.3)
- `Settings.ShellGuardOff` resolver; `live.go` drops the guardrail via `Deps.Disabled` by handle when `off`.
- `off` added to the shell-policy option list in the settings dialog.
- Test covers that `off` drops the guardrail regardless of sandbox state, and non-off keeps it.

## Checks
- `task check`, `task lint` (0 issues), `task race` all pass.

Changelog entries for both modules included. Follow-up PR bumps `zarlcode/go.mod` + `go.work` to zkit v0.5.3 after zkit is tagged.