### PR TITLE
Point zarlcode at zkit v0.5.3

### DIFF
--- a/go.work
+++ b/go.work
@@ -9,4 +9,4 @@ use (
 	./zkit
 )
 
-replace github.com/zarldev/zarlmono/zkit v0.5.2 => ./zkit
+replace github.com/zarldev/zarlmono/zkit v0.5.3 => ./zkit

--- a/zarlcode/go.mod
+++ b/zarlcode/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
-	github.com/zarldev/zarlmono/zkit v0.5.2
+	github.com/zarldev/zarlmono/zkit v0.5.3
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
Bumps `zarlcode/go.mod` and the `go.work` replace directive to zkit v0.5.3 (now tagged), ahead of tagging zarlcode v0.6.3.

Follow-up to #32.