### PR TITLE
Update artifact actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           ( cd dist && sha256sum "${archive}" > "${archive}.sha256" )
           echo "packaged dist/${archive}"
       - name: upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zarlcode-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -102,7 +102,7 @@ jobs:
           cache: true
 
       - name: download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Updates the zarlcode release workflow from actions/upload-artifact@v4 to v7 and actions/download-artifact@v4 to v8. Both current majors run natively on Node.js 24, removing the runner deprecation warning.