### PR TITLE
Clean up zkit defaults and spawn budgets

### DIFF
--- a/zkit/agent/coderunner/coderunner.go
+++ b/zkit/agent/coderunner/coderunner.go
@@ -132,8 +132,7 @@ type toolsConfig struct {
 	unrestrictedReads bool
 }
 
-// ToolsOption tunes RegisterStandardTools.
-type ToolsOption func(*toolsConfig)
+type ToolsOption = options.Option[toolsConfig]
 
 // WithToolSandbox confines shell commands behind sb (kernel-level
 // filesystem allow-list and optional network denial — see

--- a/zkit/agent/guardrails/decompose_guardrail.go
+++ b/zkit/agent/guardrails/decompose_guardrail.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zarldev/zarlmono/zkit/agent/taskscope"
 
 	"github.com/zarldev/zarlmono/zkit/ai/tools"
+	"github.com/zarldev/zarlmono/zkit/options"
 )
 
 // Default thresholds. Kept as constants so the constructor stays a
@@ -161,8 +162,7 @@ type DecomposeGuardrail struct {
 	buckets map[taskscope.ID]*decomposeBucket
 }
 
-// DecomposeGuardrailOption configures a [DecomposeGuardrail].
-type DecomposeGuardrailOption func(*DecomposeGuardrail)
+type DecomposeGuardrailOption = options.Option[DecomposeGuardrail]
 
 // WithDecomposeJudge selects the optional advisory shaper. Nil keeps the
 // deterministic advisory path.

--- a/zkit/agent/guardrails/decompose_judge.go
+++ b/zkit/agent/guardrails/decompose_judge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zarldev/zarlmono/zkit/ai/llm"
 	"github.com/zarldev/zarlmono/zkit/ai/llm/templates"
+	"github.com/zarldev/zarlmono/zkit/options"
 )
 
 // LLMVerdictJudge is the production implementation of VerdictJudge.
@@ -30,8 +31,7 @@ type LLMVerdictJudge struct {
 	maxTokens int
 }
 
-// LLMVerdictJudgeOption configures an [LLMVerdictJudge].
-type LLMVerdictJudgeOption func(*LLMVerdictJudge)
+type LLMVerdictJudgeOption = options.Option[LLMVerdictJudge]
 
 // WithVerdictMaxTokens overrides the per-verdict token cap. Non-positive
 // values leave the default unchanged.

--- a/zkit/agent/pursue/request.go
+++ b/zkit/agent/pursue/request.go
@@ -2,10 +2,10 @@ package pursue
 
 import (
 	"github.com/zarldev/zarlmono/zkit/agent/runner"
+	"github.com/zarldev/zarlmono/zkit/options"
 )
 
-// RequestOption configures a Request. See WithGoal and WithWatcher.
-type RequestOption func(*requestConfig)
+type RequestOption = options.Option[requestConfig]
 
 type requestConfig struct {
 	goal    Goal

--- a/zkit/agent/shellpolicy/policy.go
+++ b/zkit/agent/shellpolicy/policy.go
@@ -1,6 +1,10 @@
 package shellpolicy
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/zarldev/zarlmono/zkit/options"
+)
 
 // PolicyEngine converts a ParsedIR into a Decision. Decisions are driven
 // by the IR's RiskFlags plus the engine's profile flags (see relaxed);
@@ -25,8 +29,7 @@ type PolicyEngine struct {
 	relaxed bool
 }
 
-// Option configures a PolicyEngine at construction.
-type Option func(*PolicyEngine)
+type Option = options.Option[PolicyEngine]
 
 // WithRelaxed selects the relaxed profile: the ergonomic `cd` and output
 // redirect blocks step aside. Pass when the kernel sandbox is OFF. See

--- a/zkit/agent/sourcechain/sourcechain.go
+++ b/zkit/agent/sourcechain/sourcechain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zarldev/zarlmono/zkit/agent/guardrails"
 	"github.com/zarldev/zarlmono/zkit/ai/tools"
+	"github.com/zarldev/zarlmono/zkit/options"
 )
 
 // Wrapper transforms one tool source into another.
@@ -22,8 +23,7 @@ type Pipeline struct {
 	depthFilter  Wrapper
 }
 
-// PipelineOption configures a Pipeline slot.
-type PipelineOption func(*Pipeline)
+type PipelineOption = options.Option[Pipeline]
 
 // NewPipeline returns a pipeline with the supplied wrapper slots. Unset slots
 // are identity/pass-through.
@@ -74,8 +74,7 @@ type config struct {
 	extra []guardrails.Guardrail
 }
 
-// Option configures guardrail arming.
-type Option func(*config)
+type Option = options.Option[config]
 
 // WithExtraGuardrails appends truly-extra guardrails after the production set.
 func WithExtraGuardrails(extra ...guardrails.Guardrail) Option {

--- a/zkit/agent/sourcechain/sourcechain.go
+++ b/zkit/agent/sourcechain/sourcechain.go
@@ -30,9 +30,7 @@ type PipelineOption func(*Pipeline)
 func NewPipeline(opts ...PipelineOption) Pipeline {
 	var p Pipeline
 	for _, opt := range opts {
-		if opt != nil {
-			opt(&p)
-		}
+		opt(&p)
 	}
 	return p
 }
@@ -88,9 +86,7 @@ func WithExtraGuardrails(extra ...guardrails.Guardrail) Option {
 func New(wrapped tools.Source, deps guardrails.Deps, opts ...Option) (*Chain, error) {
 	var cfg config
 	for _, opt := range opts {
-		if opt != nil {
-			opt(&cfg)
-		}
+		opt(&cfg)
 	}
 
 	guards := []guardrails.Guardrail{guardrails.NewSchemaGuardrail(wrapped)}

--- a/zkit/agent/tools/program/program.go
+++ b/zkit/agent/tools/program/program.go
@@ -83,9 +83,7 @@ func NewSource(inner tools.Source, opts ...options.Option[Source]) (*Source, err
 	}
 	s := &Source{inner: inner, policy: denyAllPolicy, limits: defaultLimits()}
 	for _, opt := range opts {
-		if opt != nil {
-			opt(s)
-		}
+		opt(s)
 	}
 	if s.policy == nil {
 		s.policy = denyAllPolicy

--- a/zkit/agent/tools/spawn/spawn.go
+++ b/zkit/agent/tools/spawn/spawn.go
@@ -146,11 +146,10 @@ func WithMaxDepth(n int) options.Option[Tool] {
 	}
 }
 
-// WithSpawnMaxIterations sets a ceiling on child iterations. When the
-// model doesn't specify max_iterations (or sets it to 0), the tool
-// uses this value. When the model specifies a positive value, it's
-// clamped to this ceiling — the model cannot exceed the configured
-// sub-agent budget. Zero (the default) means "inherit from the runner".
+// WithSpawnMaxIterations sets the host-controlled child iteration budget. When
+// configured, this value is used for every child regardless of a model-supplied
+// max_iterations value, so the model cannot accidentally shorten sub-agent work.
+// Zero (the default) leaves iteration selection to the runner/tool argument.
 func WithSpawnMaxIterations(n int) options.Option[Tool] {
 	return func(t *Tool) {
 		if n >= 0 {
@@ -530,18 +529,13 @@ func pluralS(n int) string {
 }
 
 // spawnMaxIterations resolves the effective max iterations for a child task.
-// When the tool has a configured ceiling (spawnMaxIter > 0):
-//   - model-specified 0 or negative → use the ceiling
-//   - model-specified positive → clamp to the ceiling
-//
-// When the tool has no ceiling (spawnMaxIter == 0):
-//   - model-specified 0 → leave 0 (runner inherits its own default)
-//   - model-specified positive → pass through (model chooses)
+// A configured host budget always wins: treating a model-specified value as a
+// lower cap lets the model accidentally cut focused sub-agent work short (for
+// example, repeatedly choosing 5 despite a configured budget of 20). Without a
+// configured budget, preserve the model value; zero lets the runner use its
+// own default.
 func (t *Tool) spawnMaxIterations(modelSpec int) int {
-	if t.spawnMaxIter <= 0 {
-		return modelSpec
-	}
-	if modelSpec <= 0 || modelSpec > t.spawnMaxIter {
+	if t.spawnMaxIter > 0 {
 		return t.spawnMaxIter
 	}
 	return modelSpec

--- a/zkit/agent/tools/spawn/spawn_internal_test.go
+++ b/zkit/agent/tools/spawn/spawn_internal_test.go
@@ -100,6 +100,28 @@ func TestApplyPlanner_EmptyAgent_PlannerReroutes(t *testing.T) {
 	}
 }
 
+func TestSpawnMaxIterations_ConfiguredBudgetWins(t *testing.T) {
+	t.Parallel()
+	tool := New(nil, WithSpawnMaxIterations(20))
+
+	for _, modelSpec := range []int{0, 5, 20, 50} {
+		if got := tool.spawnMaxIterations(modelSpec); got != 20 {
+			t.Errorf("spawnMaxIterations(%d) = %d, want configured budget 20", modelSpec, got)
+		}
+	}
+}
+
+func TestSpawnMaxIterations_UnconfiguredPreservesModelValue(t *testing.T) {
+	t.Parallel()
+	tool := New(nil)
+
+	for _, modelSpec := range []int{0, 5, 50} {
+		if got := tool.spawnMaxIterations(modelSpec); got != modelSpec {
+			t.Errorf("spawnMaxIterations(%d) = %d, want %d", modelSpec, got, modelSpec)
+		}
+	}
+}
+
 func TestApplyPlanner_UnknownAgent_PlannerReroutes(t *testing.T) {
 	// Model emitted a name that's not in the registered set —
 	// classic confabulation case. Planner picks a valid one.

--- a/zkit/agent/tools/spawn/spawn_planner.go
+++ b/zkit/agent/tools/spawn/spawn_planner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/zarldev/zarlmono/zkit/ai/llm"
 	"github.com/zarldev/zarlmono/zkit/ai/llm/templates"
+	"github.com/zarldev/zarlmono/zkit/options"
 )
 
 const (
@@ -44,8 +45,7 @@ type LLMSpawnPlanner struct {
 	maxTokens int
 }
 
-// LLMSpawnPlannerOption configures an [LLMSpawnPlanner].
-type LLMSpawnPlannerOption func(*LLMSpawnPlanner)
+type LLMSpawnPlannerOption = options.Option[LLMSpawnPlanner]
 
 // WithPlannerMaxTokens overrides the per-plan token cap. Non-positive values
 // leave the default unchanged.

--- a/zkit/ai/retrieval/retriever.go
+++ b/zkit/ai/retrieval/retriever.go
@@ -48,9 +48,7 @@ type VectorRetriever struct {
 func (r VectorRetriever) Retrieve(ctx context.Context, query string, opts ...RetrieveOption) ([]Document, error) {
 	settings := RetrieveOptions{Limit: r.Limit}
 	for _, opt := range opts {
-		if opt != nil {
-			opt(&settings)
-		}
+		opt(&settings)
 	}
 	vectors, err := r.Embedder.Embed(ctx, []string{query})
 	if err != nil {

--- a/zkit/ai/tools/search/brave.go
+++ b/zkit/ai/tools/search/brave.go
@@ -41,9 +41,7 @@ func NewBrave(apiKey string, opts ...options.Option[braveBackend]) tools.Tool {
 		client:  zhttp.NewClient(zhttp.WithTimeout(requestTimeout)),
 	}
 	for _, opt := range opts {
-		if opt != nil {
-			opt(b)
-		}
+		opt(b)
 	}
 	return tools.NewTyped(specFor(braveDescription), b.search)
 }

--- a/zkit/ai/tools/typed.go
+++ b/zkit/ai/tools/typed.go
@@ -61,9 +61,7 @@ type typedTool[Args any, Result any] struct {
 func NewTyped[Args any, Result any](spec ToolSpec, handler TypedHandler[Args, Result], opts ...TypedOption[Result]) Tool {
 	options := typedOptions[Result]{}
 	for _, opt := range opts {
-		if opt != nil {
-			opt(&options)
-		}
+		opt(&options)
 	}
 	return typedTool[Args, Result]{spec: spec, handler: handler, options: options}
 }

--- a/zkit/zapp/zapp.go
+++ b/zkit/zapp/zapp.go
@@ -88,16 +88,8 @@ type App[T any] struct {
 
 // New creates an App for program using sensible defaults.
 func New[T any](program Program[T], opts ...options.Option[App[T]]) *App[T] {
-	app := &App[T]{
-		name:               defaultName,
-		program:            program,
-		closers:            make(map[string]io.Closer),
-		shutdownTimeout:    defaultShutdownTimeout,
-		signals:            []os.Signal{syscall.SIGINT, syscall.SIGTERM},
-		createFailureCode:  ExitFailure,
-		cleanupFailureCode: ExitFailure,
-		panicCode:          ExitPanic,
-	}
+	app := &App[T]{program: program}
+	app.normaliseDefaults()
 
 	if program != nil {
 		if name := strings.TrimSpace(program.Name()); name != "" {
@@ -106,12 +98,9 @@ func New[T any](program Program[T], opts ...options.Option[App[T]]) *App[T] {
 	}
 
 	for _, opt := range opts {
-		if opt != nil {
-			opt(app)
-		}
+		opt(app)
 	}
 
-	app.normalizeDefaults()
 	return app
 }
 
@@ -196,9 +185,6 @@ func (a *App[T]) AddCloser(name string, closer io.Closer) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.closers == nil {
-		a.closers = make(map[string]io.Closer)
-	}
 	if a.closing {
 		return ErrClosed
 	}
@@ -242,27 +228,14 @@ func (a *App[T]) handlePanic(recovered any) {
 	a.panicHandler(a.Name(), recovered)
 }
 
-func (a *App[T]) normalizeDefaults() {
-	if strings.TrimSpace(a.name) == "" {
-		a.name = defaultName
-	} else {
-		a.name = strings.TrimSpace(a.name)
-	}
-	if a.closers == nil {
-		a.closers = make(map[string]io.Closer)
-	}
-	if a.shutdownTimeout <= 0 {
-		a.shutdownTimeout = defaultShutdownTimeout
-	}
-	if a.createFailureCode == ExitOK {
-		a.createFailureCode = ExitFailure
-	}
-	if a.cleanupFailureCode == ExitOK {
-		a.cleanupFailureCode = ExitFailure
-	}
-	if a.panicCode == ExitOK {
-		a.panicCode = ExitPanic
-	}
+func (a *App[T]) normaliseDefaults() {
+	a.name = defaultName
+	a.closers = make(map[string]io.Closer)
+	a.shutdownTimeout = defaultShutdownTimeout
+	a.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	a.createFailureCode = ExitFailure
+	a.cleanupFailureCode = ExitFailure
+	a.panicCode = ExitPanic
 }
 
 type closerEntry struct {
@@ -271,12 +244,8 @@ type closerEntry struct {
 }
 
 func (a *App[T]) closeWithTimeout() error {
-	ctx := context.Background()
-	if a.shutdownTimeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, a.shutdownTimeout)
-		defer cancel()
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), a.shutdownTimeout)
+	defer cancel()
 	return a.Close(ctx)
 }
 
@@ -293,7 +262,7 @@ func (a *App[T]) drainClosers() []closerEntry {
 	for i := len(a.order) - 1; i >= 0; i-- {
 		name := a.order[i]
 		closer, ok := a.closers[name]
-		if !ok || closer == nil {
+		if !ok {
 			continue
 		}
 		entries = append(entries, closerEntry{name: name, closer: closer})

--- a/zkit/zhttp/server.go
+++ b/zkit/zhttp/server.go
@@ -40,9 +40,7 @@ func DefaultServerConfig() ServerConfig {
 func NewServer(addr string, handler http.Handler, opts ...options.Option[ServerConfig]) *http.Server {
 	cfg := DefaultServerConfig()
 	for _, opt := range opts {
-		if opt != nil {
-			opt(&cfg)
-		}
+		opt(&cfg)
 	}
 	return &http.Server{
 		Addr:              addr,


### PR DESCRIPTION
## Summary
- centralize `zapp` default initialization in `normaliseDefaults`
- remove redundant defensive checks after constructor defaults and validation
- remove redundant nil functional-option guards across `zkit`
- use canonical `options.Option[T]` aliases across agent packages
- make the configured host spawn iteration budget override model-supplied values

## Testing
- `go test -C zkit -count=1 ./zapp`
- `go test -C zkit -count=1 ./zhttp ./ai/tools ./ai/tools/search ./ai/retrieval ./agent/sourcechain ./agent/tools/program`
- `go test -C zkit -count=1 ./agent/tools/spawn ./agent/sourcechain ./agent/shellpolicy ./agent/pursue ./agent/coderunner ./agent/guardrails`
- `go test -C zarlcode -count=1 ./engine`
- `git diff --check`