### PR TITLE
Prepare zkit and zarlcode v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [zarlcode/v0.12.0] — 2026-08-23
+`zarlcode/v0.12.0`
+
+### Changed
+
+- Standardized agent configuration on canonical functional options.
+- Configured spawn iteration budgets now take precedence over model-supplied values.
+
+## [zkit/v0.12.0] — 2026-08-23
+`zkit/v0.12.0`
+
+### Changed
+
+- Centralized `zapp` default initialization and removed redundant defensive checks.
+- Standardized agent functional options on `options.Option[T]`.
+- Configured spawn iteration budgets now take precedence over model-supplied values.
+
 ## [zarlcode/v0.11.0] — 2026-08-21
 `zarlcode/v0.11.0`
 

--- a/go.work
+++ b/go.work
@@ -8,6 +8,6 @@ use (
 	./zkit
 )
 
-replace github.com/zarldev/zarlmono/zkit v0.11.1 => ./zkit
+replace github.com/zarldev/zarlmono/zkit v0.12.0 => ./zkit
 
 replace github.com/zarldev/zarlmono/zarlcode v0.9.0 => ./zarlcode

--- a/zarlcode/go.mod
+++ b/zarlcode/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
-	github.com/zarldev/zarlmono/zkit v0.11.1
+	github.com/zarldev/zarlmono/zkit v0.12.0
 	golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary
- add zkit and zarlcode v0.12.0 changelog entries
- pin zarlcode to zkit v0.12.0
- update the workspace replacement for release verification

## Verification
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false go tool task check`
- `go tool task lint`
- `git diff --check`