### PR TITLE
Add zsync collection conveniences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [zkit/v0.13.0] — 2026-08-24
+`zkit/v0.13.0`
+
+### Added
+
+- Added variadic initial values to `zsync.NewSet` and `zsync.NewQueue`.
+- Added independent snapshots for `zsync.Map` and `zsync.Queue`.
+- Added atomic batch updates with `Set.AddAll`, `Set.RemoveAll`, and `Queue.PushMany`.
+
 ## [zarlcode/v0.12.0] — 2026-08-23
 `zarlcode/v0.12.0`
 

--- a/zkit/zsync/map.go
+++ b/zkit/zsync/map.go
@@ -94,6 +94,17 @@ func (m *Map[K, V]) Keys() []K {
 	return keys
 }
 
+// Snapshot returns a copy of the current entries.
+func (m *Map[K, V]) Snapshot() map[K]V {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	snapshot := make(map[K]V, len(m.data))
+	for key, value := range m.data {
+		snapshot[key] = value
+	}
+	return snapshot
+}
+
 // Clear removes all entries.
 func (m *Map[K, V]) Clear() {
 	m.mu.Lock()

--- a/zkit/zsync/map_test.go
+++ b/zkit/zsync/map_test.go
@@ -262,6 +262,30 @@ func TestMap_Clear(t *testing.T) {
 	}
 }
 
+func TestMap_Snapshot(t *testing.T) {
+	m := zsync.NewMap[string, int]()
+	m.Set("one", 1)
+	m.Set("two", 2)
+
+	snapshot := m.Snapshot()
+	snapshot["one"] = 10
+	delete(snapshot, "two")
+
+	if value, err := m.Get("one"); err != nil || value != 1 {
+		t.Errorf("Get(one) = (%d, %v), want (1, nil)", value, err)
+	}
+	if value, err := m.Get("two"); err != nil || value != 2 {
+		t.Errorf("Get(two) = (%d, %v), want (2, nil)", value, err)
+	}
+}
+
+func TestMap_SnapshotZeroValue(t *testing.T) {
+	var m zsync.Map[string, int]
+	if got := m.Snapshot(); len(got) != 0 {
+		t.Errorf("Snapshot() = %v, want empty map", got)
+	}
+}
+
 func TestMap_LoadOrStore(t *testing.T) {
 	m := zsync.NewMap[string, int]()
 

--- a/zkit/zsync/queue.go
+++ b/zkit/zsync/queue.go
@@ -19,9 +19,9 @@ type Queue[T any] struct {
 
 var _ io.Closer = (*Queue[any])(nil)
 
-// NewQueue creates a new thread-safe FIFO queue.
-func NewQueue[T any]() *Queue[T] {
-	q := &Queue[T]{}
+// NewQueue creates a new thread-safe FIFO queue containing items.
+func NewQueue[T any](items ...T) *Queue[T] {
+	q := &Queue[T]{items: append([]T(nil), items...)}
 	q.cond = sync.NewCond(&q.mu)
 	return q
 }
@@ -36,6 +36,21 @@ func (q *Queue[T]) Push(item T) error {
 	}
 	q.items = append(q.items, item)
 	q.cond.Signal()
+	return nil
+}
+
+// PushMany atomically adds items to the back of the queue. It returns
+// ErrQueueClosed without adding any items after Close.
+func (q *Queue[T]) PushMany(items ...T) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return ErrQueueClosed
+	}
+	q.items = append(q.items, items...)
+	if len(items) > 0 {
+		q.cond.Broadcast()
+	}
 	return nil
 }
 
@@ -131,6 +146,13 @@ func (q *Queue[T]) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return len(q.items)
+}
+
+// Snapshot returns a copy of the queued items in FIFO order.
+func (q *Queue[T]) Snapshot() []T {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return append([]T(nil), q.items...)
 }
 
 // Close marks the queue closed and wakes every waiter. Push fails

--- a/zkit/zsync/queue_test.go
+++ b/zkit/zsync/queue_test.go
@@ -3,6 +3,7 @@ package zsync_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -10,6 +11,22 @@ import (
 
 	"github.com/zarldev/zarlmono/zkit/zsync"
 )
+
+func TestNewQueue(t *testing.T) {
+	items := []string{"first", "second"}
+	queue := zsync.NewQueue(items...)
+	items[0] = "changed"
+
+	for _, want := range []string{"first", "second"} {
+		got, err := queue.TryPop()
+		if err != nil {
+			t.Fatalf("TryPop() error = %v", err)
+		}
+		if got != want {
+			t.Errorf("TryPop() = %q, want %q", got, want)
+		}
+	}
+}
 
 func TestQueue_Push(t *testing.T) {
 	tests := []struct {
@@ -66,6 +83,80 @@ func TestQueue_Push(t *testing.T) {
 				t.Errorf("Len() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestQueue_PushMany(t *testing.T) {
+	t.Run("preserves order", func(t *testing.T) {
+		queue := zsync.NewQueue("existing")
+		if err := queue.PushMany("first", "second"); err != nil {
+			t.Fatalf("PushMany() error = %v", err)
+		}
+		if got := queue.Snapshot(); !slices.Equal(got, []string{"existing", "first", "second"}) {
+			t.Errorf("Snapshot() = %v, want [existing first second]", got)
+		}
+	})
+
+	t.Run("closed queue is unchanged", func(t *testing.T) {
+		queue := zsync.NewQueue("existing")
+		if err := queue.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		if err := queue.PushMany("first", "second"); !errors.Is(err, zsync.ErrQueueClosed) {
+			t.Errorf("PushMany() error = %v, want %v", err, zsync.ErrQueueClosed)
+		}
+		if got := queue.Snapshot(); !slices.Equal(got, []string{"existing"}) {
+			t.Errorf("Snapshot() = %v, want [existing]", got)
+		}
+	})
+}
+
+func TestQueue_PushManyWakesWaiters(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		queue := zsync.NewQueue[string]()
+		results := make(chan string, 2)
+		for range 2 {
+			go func() {
+				item, err := queue.Pop()
+				if err != nil {
+					t.Errorf("Pop() error = %v", err)
+					return
+				}
+				results <- item
+			}()
+		}
+		synctest.Wait()
+
+		if err := queue.PushMany("first", "second"); err != nil {
+			t.Fatalf("PushMany() error = %v", err)
+		}
+		synctest.Wait()
+
+		got := []string{<-results, <-results}
+		slices.Sort(got)
+		if !slices.Equal(got, []string{"first", "second"}) {
+			t.Errorf("popped items = %v, want [first second]", got)
+		}
+	})
+}
+
+func TestQueue_Snapshot(t *testing.T) {
+	queue := zsync.NewQueue("first", "second")
+	snapshot := queue.Snapshot()
+	snapshot[0] = "changed"
+
+	if got := queue.Snapshot(); !slices.Equal(got, []string{"first", "second"}) {
+		t.Errorf("Snapshot() = %v, want [first second]", got)
+	}
+}
+
+func TestQueue_SnapshotAfterClose(t *testing.T) {
+	queue := zsync.NewQueue("first", "second")
+	if err := queue.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if got := queue.Snapshot(); !slices.Equal(got, []string{"first", "second"}) {
+		t.Errorf("Snapshot() = %v, want [first second]", got)
 	}
 }
 

--- a/zkit/zsync/set.go
+++ b/zkit/zsync/set.go
@@ -10,14 +10,30 @@ type Set[T comparable] struct {
 	m *Map[T, struct{}]
 }
 
-// NewSet creates a new thread-safe set.
-func NewSet[T comparable]() *Set[T] {
-	return &Set[T]{m: NewMap[T, struct{}]()}
+// NewSet creates a new thread-safe set containing values.
+func NewSet[T comparable](values ...T) *Set[T] {
+	set := &Set[T]{m: NewMap[T, struct{}]()}
+	for _, value := range values {
+		set.Add(value)
+	}
+	return set
 }
 
 // Add inserts a value. No-op if already present.
 func (s *Set[T]) Add(value T) {
 	s.m.Set(value, struct{}{})
+}
+
+// AddAll inserts values atomically. Existing values are unchanged.
+func (s *Set[T]) AddAll(values ...T) {
+	s.m.mu.Lock()
+	defer s.m.mu.Unlock()
+	if s.m.data == nil {
+		s.m.data = make(map[T]struct{}, len(values))
+	}
+	for _, value := range values {
+		s.m.data[value] = struct{}{}
+	}
 }
 
 // AddIfAbsent inserts value when it is not already present.
@@ -36,6 +52,15 @@ func (s *Set[T]) Contains(value T) bool {
 // Remove deletes a value. Returns true if it existed.
 func (s *Set[T]) Remove(value T) bool {
 	return s.m.Delete(value)
+}
+
+// RemoveAll removes values atomically.
+func (s *Set[T]) RemoveAll(values ...T) {
+	s.m.mu.Lock()
+	defer s.m.mu.Unlock()
+	for _, value := range values {
+		delete(s.m.data, value)
+	}
 }
 
 // Len returns the current member count.

--- a/zkit/zsync/set_test.go
+++ b/zkit/zsync/set_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/zarldev/zarlmono/zkit/zsync"
 )
 
+func TestNewSet(t *testing.T) {
+	values := []string{"accepted", "created", "accepted"}
+	set := zsync.NewSet(values...)
+
+	if got := set.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+	for _, value := range []string{"accepted", "created"} {
+		if !set.Contains(value) {
+			t.Errorf("Contains(%q) = false, want true", value)
+		}
+	}
+}
+
 func TestSet_Add(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -50,6 +64,20 @@ func TestSet_Add(t *testing.T) {
 				t.Errorf("Len() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSet_AddAll(t *testing.T) {
+	set := zsync.NewSet("existing")
+	set.AddAll("first", "second", "first")
+
+	if got := set.Len(); got != 3 {
+		t.Fatalf("Len() = %d, want 3", got)
+	}
+	for _, value := range []string{"existing", "first", "second"} {
+		if !set.Contains(value) {
+			t.Errorf("Contains(%q) = false, want true", value)
+		}
 	}
 }
 
@@ -209,6 +237,15 @@ func TestSet_Remove(t *testing.T) {
 				t.Errorf("Len() after remove = %v, want %v", s.Len(), tt.length)
 			}
 		})
+	}
+}
+
+func TestSet_RemoveAll(t *testing.T) {
+	set := zsync.NewSet("first", "second", "third")
+	set.RemoveAll("first", "third", "missing")
+
+	if got := set.Values(); !slices.Equal(got, []string{"second"}) {
+		t.Errorf("Values() = %v, want [second]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow `NewSet` and `NewQueue` to accept initial values
- add independent map and queue snapshots
- add atomic set and queue batch operations
- prepare the zkit v0.13.0 changelog

## Verification
- `go test -C zkit -count=1 ./zsync`
- `go test -C zkit -race -count=1 ./zsync`
- `go test -C zarlcode -count=1 ./engine`
- `go tool task check`
- `go tool task lint`
- `git diff --check`