### PR TITLE
test: cover NATS and MongoDB adapters

### DIFF
--- a/zkit/docstore/docstore_test.go
+++ b/zkit/docstore/docstore_test.go
@@ -81,6 +81,7 @@ func TestMongoStoreContract(t *testing.T) {
 		if closed {
 			return
 		}
+		// Test cleanup runs after t.Context is canceled; preserve only its values.
 		ctx, cleanupCancel := context.WithTimeout(context.WithoutCancel(t.Context()), 10*time.Second)
 		defer cleanupCancel()
 		if err := database.Collection("records").Drop(ctx); err != nil {

--- a/zkit/docstore/docstore_test.go
+++ b/zkit/docstore/docstore_test.go
@@ -3,17 +3,43 @@ package docstore_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/zarldev/zarlmono/zkit/docstore"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type note struct {
-	Title string
-	Tags  []string
+	Title     string             `bson:"title"`
+	Tags      []string           `bson:"tags"`
+	CreatedAt time.Time          `bson:"created_at"`
+	Token     primitive.ObjectID `bson:"token"`
+	Blob      []byte             `bson:"blob"`
+	Scores    map[string]int     `bson:"scores"`
 }
 
-func (n note) Clone() note { n.Tags = append([]string(nil), n.Tags...); return n }
+func (n note) Clone() note {
+	n.Tags = append([]string(nil), n.Tags...)
+	n.Blob = append([]byte(nil), n.Blob...)
+	n.Scores = cloneMap(n.Scores)
+	return n
+}
+
+func cloneMap[K comparable, V any](src map[K]V) map[K]V {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[K]V, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
 
 type store interface {
 	Create(context.Context, docstore.Record[note]) (docstore.Record[note], error)
@@ -25,64 +51,207 @@ type store interface {
 	Count(context.Context) (int, error)
 }
 
-func TestMemoryStoreContract(t *testing.T) { testStore(t, docstore.NewMemoryStore[note]()) }
+func TestMemoryStoreContract(t *testing.T) {
+	testStoreContract(t, docstore.NewMemoryStore[note]())
+}
 
-func testStore(t *testing.T, store store) {
+func TestMongoStoreContract(t *testing.T) {
+	uri, ok := os.LookupEnv("MONGODB_URI")
+	if !ok {
+		t.Skip("MONGODB_URI is not set; skipping MongoStore contract")
+	}
+	if uri == "" {
+		t.Fatal("MONGODB_URI is set but empty")
+	}
+
+	connectCtx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	databaseName := fmt.Sprintf("zarlcode_docstore_contract_%d", time.Now().UnixNano())
+	database, err := docstore.ConnectMongo(
+		connectCtx,
+		docstore.WithMongoURI(uri),
+		docstore.WithDatabaseName(databaseName),
+		docstore.WithPoolSize(0, 4),
+	)
+	if err != nil {
+		t.Fatalf("ConnectMongo with configured MONGODB_URI: %v", err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if closed {
+			return
+		}
+		ctx, cleanupCancel := context.WithTimeout(context.WithoutCancel(t.Context()), 10*time.Second)
+		defer cleanupCancel()
+		if err := database.Collection("records").Drop(ctx); err != nil {
+			t.Errorf("drop MongoDB contract collection: %v", err)
+		}
+		if err := database.Close(ctx); err != nil {
+			t.Errorf("close MongoDB contract database: %v", err)
+		}
+	})
+
+	mongoStore := docstore.NewMongoStore[note](database.Collection("records"))
+	testStoreContract(t, mongoStore)
+
+	closeCtx, closeCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	if err := database.Collection("records").Drop(closeCtx); err != nil {
+		closeCancel()
+		t.Fatalf("drop MongoDB contract collection: %v", err)
+	}
+	if err := database.Close(closeCtx); err != nil {
+		closeCancel()
+		t.Fatalf("Close: %v", err)
+	}
+	closeCancel()
+	closed = true
+	if _, err := mongoStore.Count(t.Context()); err == nil {
+		t.Error("Count after Close succeeded, want error")
+	}
+}
+
+func testStoreContract(t *testing.T, store store) {
 	t.Helper()
 	ctx := t.Context()
-	first := docstore.Record[note]{ID: "b", Value: note{Title: "before", Tags: []string{"one"}}}
+	first := docstore.Record[note]{
+		ID: "b",
+		Value: note{
+			Title:     "before",
+			Tags:      []string{"one", "two"},
+			CreatedAt: time.UnixMilli(1_704_067_200_123).UTC(),
+			Token:     primitive.NewObjectID(),
+			Blob:      []byte{0, 1, 2, 255},
+			Scores:    map[string]int{"one": 1, "two": 2},
+		},
+	}
 	created, err := store.Create(ctx, first)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Create: %v", err)
 	}
+	firstSnapshot := first.Value.Clone()
 	first.Value.Tags[0] = "caller-mutated"
+	first.Value.Blob[0] = 9
+	first.Value.Scores["one"] = 9
 	created.Value.Tags[0] = "returned-mutated"
+	created.Value.Blob[0] = 8
+	created.Value.Scores["one"] = 8
+
 	read, err := store.Read(ctx, "b")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Read: %v", err)
 	}
-	if got, want := read.Value.Tags[0], "one"; got != want {
-		t.Fatalf("stored tag = %q, want %q", got, want)
+	if !reflect.DeepEqual(read.Value, firstSnapshot) {
+		t.Fatalf("Read BSON fidelity = %#v, want %#v", read.Value, firstSnapshot)
 	}
 	read.Value.Tags[0] = "read-mutated"
+	read.Value.Blob[0] = 7
+	read.Value.Scores["one"] = 7
 	read, err = store.Read(ctx, "b")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("second Read: %v", err)
 	}
-	if got, want := read.Value.Tags[0], "one"; got != want {
-		t.Fatalf("read leaked alias: %q", got)
+	if !reflect.DeepEqual(read.Value, firstSnapshot) {
+		t.Fatalf("Read leaked mutable alias: %#v", read.Value)
 	}
+
 	if _, err := store.Create(ctx, first); !errors.Is(err, docstore.ErrConflict) {
-		t.Fatalf("duplicate error = %v", err)
+		t.Fatalf("duplicate Create error = %v, want ErrConflict", err)
 	}
 	if _, err := store.Replace(ctx, docstore.Record[note]{ID: "missing", Value: note{}}); !errors.Is(err, docstore.ErrNotFound) {
-		t.Fatalf("replace missing = %v", err)
+		t.Fatalf("Replace missing error = %v, want ErrNotFound", err)
 	}
 	if err := store.Delete(ctx, "missing"); !errors.Is(err, docstore.ErrNotFound) {
-		t.Fatalf("delete missing = %v", err)
+		t.Fatalf("Delete missing error = %v, want ErrNotFound", err)
 	}
-	if _, err := store.Create(ctx, docstore.Record[note]{ID: "a", Value: note{Title: "a"}}); err != nil {
-		t.Fatal(err)
+	for name, operation := range map[string]func() error{
+		"Create":  func() error { _, err := store.Create(ctx, docstore.Record[note]{}); return err },
+		"Replace": func() error { _, err := store.Replace(ctx, docstore.Record[note]{}); return err },
+		"Put":     func() error { _, err := store.Put(ctx, docstore.Record[note]{}); return err },
+	} {
+		if err := operation(); !errors.Is(err, docstore.ErrInvalidRecord) {
+			t.Errorf("%s empty ID error = %v, want ErrInvalidRecord", name, err)
+		}
 	}
-	list, err := store.List(ctx, docstore.Page{Limit: 1})
+
+	replaced := docstore.Record[note]{ID: "b", Value: note{Title: "replaced", Tags: []string{"new"}}}
+	if _, err := store.Replace(ctx, replaced); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	assertReadTitle(t, ctx, store, "b", "replaced")
+	if _, err := store.Put(ctx, docstore.Record[note]{ID: "b", Value: note{Title: "updated"}}); err != nil {
+		t.Fatalf("Put existing: %v", err)
+	}
+	if _, err := store.Put(ctx, docstore.Record[note]{ID: "c", Value: note{Title: "created by put"}}); err != nil {
+		t.Fatalf("Put new: %v", err)
+	}
+	if _, err := store.Create(ctx, docstore.Record[note]{ID: "a", Value: note{Title: "created"}}); err != nil {
+		t.Fatalf("Create a: %v", err)
+	}
+
+	count, err := store.Count(ctx)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Count: %v", err)
 	}
-	if len(list) != 1 || list[0].ID != "a" {
-		t.Fatalf("list = %#v", list)
+	if count != 3 {
+		t.Fatalf("Count = %d, want 3", count)
 	}
-	if _, err := store.List(ctx, docstore.Page{Offset: -1}); !errors.Is(err, docstore.ErrInvalidRecord) {
-		t.Fatalf("bad page error = %v", err)
+	assertListIDs(t, ctx, store, docstore.Page{}, "a", "b", "c")
+	assertListIDs(t, ctx, store, docstore.Page{Offset: 1, Limit: 1}, "b")
+	assertListIDs(t, ctx, store, docstore.Page{Offset: 2}, "c")
+	assertListIDs(t, ctx, store, docstore.Page{Offset: 20})
+	for _, page := range []docstore.Page{{Offset: -1}, {Limit: -1}} {
+		if _, err := store.List(ctx, page); !errors.Is(err, docstore.ErrInvalidRecord) {
+			t.Errorf("List(%+v) error = %v, want ErrInvalidRecord", page, err)
+		}
 	}
+
 	canceled, cancel := context.WithCancel(ctx)
 	cancel()
-	if _, err := store.Count(canceled); !errors.Is(err, context.Canceled) {
-		t.Fatalf("canceled count = %v", err)
+	canceledOperations := map[string]func() error{
+		"Create":  func() error { _, err := store.Create(canceled, docstore.Record[note]{ID: "cancel-create"}); return err },
+		"Read":    func() error { _, err := store.Read(canceled, "a"); return err },
+		"Replace": func() error { _, err := store.Replace(canceled, docstore.Record[note]{ID: "a"}); return err },
+		"Put":     func() error { _, err := store.Put(canceled, docstore.Record[note]{ID: "cancel-put"}); return err },
+		"Delete":  func() error { return store.Delete(canceled, "a") },
+		"List":    func() error { _, err := store.List(canceled, docstore.Page{}); return err },
+		"Count":   func() error { _, err := store.Count(canceled); return err },
 	}
+	for name, operation := range canceledOperations {
+		if err := operation(); !errors.Is(err, context.Canceled) {
+			t.Errorf("%s canceled error = %v, want context.Canceled", name, err)
+		}
+	}
+
 	if err := store.Delete(ctx, "b"); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Delete: %v", err)
 	}
 	if _, err := store.Read(ctx, "b"); !errors.Is(err, docstore.ErrNotFound) {
-		t.Fatalf("read deleted = %v", err)
+		t.Fatalf("Read deleted error = %v, want ErrNotFound", err)
+	}
+}
+
+func assertReadTitle(t *testing.T, ctx context.Context, store store, id docstore.ID, want string) {
+	t.Helper()
+	record, err := store.Read(ctx, id)
+	if err != nil {
+		t.Fatalf("Read(%q): %v", id, err)
+	}
+	if record.Value.Title != want {
+		t.Fatalf("Read(%q) title = %q, want %q", id, record.Value.Title, want)
+	}
+}
+
+func assertListIDs(t *testing.T, ctx context.Context, store store, page docstore.Page, want ...docstore.ID) {
+	t.Helper()
+	records, err := store.List(ctx, page)
+	if err != nil {
+		t.Fatalf("List(%+v): %v", page, err)
+	}
+	got := make([]docstore.ID, len(records))
+	for i, record := range records {
+		got[i] = record.ID
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("List(%+v) IDs = %v, want %v", page, got, want)
 	}
 }

--- a/zkit/docstore/docstore_test.go
+++ b/zkit/docstore/docstore_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zarldev/zarlmono/zkit/docstore"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/zarldev/zarlmono/zkit/docstore"
 )
 
 type note struct {

--- a/zkit/messagebus/nats.go
+++ b/zkit/messagebus/nats.go
@@ -340,6 +340,9 @@ func (b *NATSBus[T]) wrapHandler(subCtx context.Context, handler Handler[T]) nat
 				headers[k] = v[0]
 			}
 		}
+		if msg.Reply != "" {
+			headers.Set("reply-to", msg.Reply)
+		}
 
 		var timestamp time.Time
 		if ts := headers.Get("timestamp"); ts != "" {

--- a/zkit/messagebus/nats_test.go
+++ b/zkit/messagebus/nats_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+
 	"github.com/zarldev/zarlmono/zkit/messagebus"
 )
 

--- a/zkit/messagebus/nats_test.go
+++ b/zkit/messagebus/nats_test.go
@@ -1,0 +1,314 @@
+package messagebus_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/zarldev/zarlmono/zkit/messagebus"
+)
+
+func TestJSONSerializer(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		serializer := messagebus.JSONSerializer[TestEvent]{}
+		want := TestEvent{ID: 42, Message: "round trip"}
+		payload, err := serializer.Encode(want)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		got, err := serializer.Decode(payload)
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("round trip = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("malformed payload", func(t *testing.T) {
+		serializer := messagebus.JSONSerializer[TestEvent]{}
+		got, err := serializer.Decode([]byte(`{"id":`))
+		if err == nil {
+			t.Fatal("Decode malformed payload succeeded")
+		}
+		if got != (TestEvent{}) {
+			t.Fatalf("Decode malformed payload = %#v, want zero value", got)
+		}
+	})
+}
+
+func TestNATSBusContract(t *testing.T) {
+	url := requiredIntegrationURL(t, "NATS_URL")
+	prefix := fmt.Sprintf("zarlcode.contract.%d", time.Now().UnixNano())
+	bus, err := messagebus.NewNATSBus[TestEvent](
+		messagebus.WithNATSURL[TestEvent](url),
+		messagebus.WithNATSTimeout[TestEvent](5*time.Second),
+		messagebus.WithMaxReconnect[TestEvent](0),
+	)
+	if err != nil {
+		t.Fatalf("NewNATSBus with configured NATS_URL: %v", err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			if err := bus.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		}
+	})
+
+	t.Run("publish subscribe and headers", func(t *testing.T) {
+		received := make(chan messagebus.Message[TestEvent], 2)
+		sub, err := bus.Subscribe(t.Context(), prefix+".events", func(_ context.Context, msg messagebus.Message[TestEvent]) error {
+			received <- msg
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		defer func() { _ = sub.Unsubscribe() }()
+
+		plain := TestEvent{ID: 1, Message: "plain"}
+		if err := bus.Publish(t.Context(), prefix+".events", plain); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+		assertMessage(t, receiveMessage(t, received), prefix+".events", plain, "", "")
+
+		withHeaders := TestEvent{ID: 2, Message: "headers"}
+		if err := bus.PublishWithHeaders(t.Context(), prefix+".events", withHeaders, messagebus.Headers{"trace-id": "trace-123"}); err != nil {
+			t.Fatalf("PublishWithHeaders: %v", err)
+		}
+		assertMessage(t, receiveMessage(t, received), prefix+".events", withHeaders, "trace-id", "trace-123")
+	})
+
+	t.Run("queue group", func(t *testing.T) {
+		deliveries := make(chan int, 8)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		first, err := bus.QueueSubscribe(ctx, prefix+".queue", "workers", func(context.Context, messagebus.Message[TestEvent]) error {
+			deliveries <- 1
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("first QueueSubscribe: %v", err)
+		}
+		defer func() { _ = first.Unsubscribe() }()
+		second, err := bus.QueueSubscribe(ctx, prefix+".queue", "workers", func(context.Context, messagebus.Message[TestEvent]) error {
+			deliveries <- 2
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("second QueueSubscribe: %v", err)
+		}
+		defer func() { _ = second.Unsubscribe() }()
+
+		for i := range 8 {
+			if err := bus.Publish(t.Context(), prefix+".queue", TestEvent{ID: i}); err != nil {
+				t.Fatalf("Publish queue item %d: %v", i, err)
+			}
+		}
+		counts := map[int]int{}
+		for range 8 {
+			counts[receiveWithin(t, deliveries)]++
+		}
+		if counts[1] == 0 || counts[2] == 0 {
+			t.Fatalf("queue deliveries = %v, want both subscribers to receive work", counts)
+		}
+	})
+
+	t.Run("request reply", func(t *testing.T) {
+		sub, err := bus.Subscribe(t.Context(), prefix+".request", func(ctx context.Context, msg messagebus.Message[TestEvent]) error {
+			replyTo := msg.Headers.Get("reply-to")
+			if replyTo == "" {
+				return errors.New("request did not expose reply subject")
+			}
+			return bus.Publish(ctx, replyTo, TestEvent{ID: msg.Data.ID * 2, Message: "reply: " + msg.Data.Message})
+		})
+		if err != nil {
+			t.Fatalf("Subscribe responder: %v", err)
+		}
+		defer func() { _ = sub.Unsubscribe() }()
+
+		got, err := bus.Request(t.Context(), prefix+".request", TestEvent{ID: 5, Message: "request"}, 2*time.Second)
+		if err != nil {
+			t.Fatalf("Request: %v", err)
+		}
+		want := TestEvent{ID: 10, Message: "reply: request"}
+		if got != want {
+			t.Fatalf("Request reply = %#v, want %#v", got, want)
+		}
+
+		started := time.Now()
+		if _, err := bus.Request(t.Context(), prefix+".no-responder", TestEvent{}, 100*time.Millisecond); err == nil {
+			t.Fatal("Request without responder succeeded")
+		}
+		if elapsed := time.Since(started); elapsed > time.Second {
+			t.Fatalf("Request timeout took %v, want less than 1s", elapsed)
+		}
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		canceled, cancel := context.WithCancel(t.Context())
+		cancel()
+		if err := bus.Publish(canceled, prefix+".canceled", TestEvent{}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Publish canceled error = %v, want context.Canceled", err)
+		}
+		if _, err := bus.Subscribe(canceled, prefix+".canceled", func(context.Context, messagebus.Message[TestEvent]) error { return nil }); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Subscribe canceled error = %v, want context.Canceled", err)
+		}
+		if _, err := bus.Request(canceled, prefix+".canceled", TestEvent{}, time.Second); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Request canceled error = %v, want context.Canceled", err)
+		}
+
+		subCtx, subCancel := context.WithCancel(t.Context())
+		sub, err := bus.Subscribe(subCtx, prefix+".cancel-sub", func(context.Context, messagebus.Message[TestEvent]) error { return nil })
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		if !sub.IsValid() {
+			t.Fatal("new subscription is invalid")
+		}
+		subCancel()
+		waitFor(t, func() bool { return !sub.IsValid() }, "subscription to become invalid after context cancellation")
+	})
+
+	t.Run("close", func(t *testing.T) {
+		sub, err := bus.Subscribe(t.Context(), prefix+".close", func(context.Context, messagebus.Message[TestEvent]) error { return nil })
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		if err := bus.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		closed = true
+		waitFor(t, func() bool { return !sub.IsValid() }, "subscription to become invalid after Close")
+		if err := bus.Publish(t.Context(), prefix+".close", TestEvent{}); err == nil {
+			t.Error("Publish after Close succeeded")
+		}
+		if _, err := bus.Subscribe(t.Context(), prefix+".close", func(context.Context, messagebus.Message[TestEvent]) error { return nil }); err == nil {
+			t.Error("Subscribe after Close succeeded")
+		}
+	})
+}
+
+func TestNATSBusJetStream(t *testing.T) {
+	url := requiredIntegrationURL(t, "NATS_URL")
+	admin, err := nats.Connect(url, nats.Timeout(5*time.Second), nats.MaxReconnects(0))
+	if err != nil {
+		t.Fatalf("connect to configured NATS_URL for JetStream setup: %v", err)
+	}
+	t.Cleanup(admin.Close)
+	js, err := admin.JetStream()
+	if err != nil {
+		t.Fatalf("create JetStream setup context: %v", err)
+	}
+	if _, err := js.AccountInfo(); err != nil {
+		if errors.Is(err, nats.ErrNoResponders) {
+			t.Skipf("NATS_URL is reachable but JetStream is not enabled: %v", err)
+		}
+		t.Fatalf("query JetStream account: %v", err)
+	}
+
+	suffix := time.Now().UnixNano()
+	stream := fmt.Sprintf("ZARLCODE_CONTRACT_%d", suffix)
+	subject := fmt.Sprintf("zarlcode.jetstream.contract.%d", suffix)
+	if _, err := js.AddStream(&nats.StreamConfig{Name: stream, Subjects: []string{subject}, Storage: nats.MemoryStorage}); err != nil {
+		t.Fatalf("AddStream: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := js.DeleteStream(stream); err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+			t.Errorf("DeleteStream: %v", err)
+		}
+	})
+
+	bus, err := messagebus.NewNATSBus[TestEvent](
+		messagebus.WithNATSURL[TestEvent](url),
+		messagebus.WithNATSTimeout[TestEvent](5*time.Second),
+		messagebus.WithMaxReconnect[TestEvent](0),
+		messagebus.WithJetStream[TestEvent](),
+	)
+	if err != nil {
+		t.Fatalf("NewNATSBus with JetStream: %v", err)
+	}
+	defer func() {
+		if err := bus.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	received := make(chan messagebus.Message[TestEvent], 1)
+	sub, err := bus.Subscribe(t.Context(), subject, func(_ context.Context, msg messagebus.Message[TestEvent]) error {
+		received <- msg
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+	want := TestEvent{ID: 7, Message: "jetstream"}
+	if err := bus.PublishWithHeaders(t.Context(), subject, want, messagebus.Headers{"mode": "jetstream"}); err != nil {
+		t.Fatalf("PublishWithHeaders: %v", err)
+	}
+	assertMessage(t, receiveMessage(t, received), subject, want, "mode", "jetstream")
+}
+
+func requiredIntegrationURL(t *testing.T, name string) string {
+	t.Helper()
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		t.Skipf("%s is not set; skipping integration contract", name)
+	}
+	if value == "" {
+		t.Fatalf("%s is set but empty", name)
+	}
+	return value
+}
+
+func receiveMessage(t *testing.T, messages <-chan messagebus.Message[TestEvent]) messagebus.Message[TestEvent] {
+	t.Helper()
+	return receiveWithin(t, messages)
+}
+
+func receiveWithin[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(3 * time.Second):
+		var zero T
+		t.Fatal("timed out waiting for message")
+		return zero
+	}
+}
+
+func assertMessage(t *testing.T, got messagebus.Message[TestEvent], wantSubject string, wantData TestEvent, header, wantHeader string) {
+	t.Helper()
+	if got.Subject != wantSubject {
+		t.Errorf("subject = %q, want %q", got.Subject, wantSubject)
+	}
+	if got.Data != wantData {
+		t.Errorf("data = %#v, want %#v", got.Data, wantData)
+	}
+	if header != "" && got.Headers.Get(header) != wantHeader {
+		t.Errorf("header %q = %q, want %q", header, got.Headers.Get(header), wantHeader)
+	}
+	if got.Timestamp.IsZero() {
+		t.Error("timestamp is zero")
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
- add black-box JSON serializer and opt-in NATS adapter contracts
- reuse the document-store contract for opt-in MongoDB coverage
- cover CRUD, ordering, pagination, cancellation, lifecycle, headers, queues, request/reply, and JetStream
- expose the native NATS reply subject through the existing reply-to header

## Verification
- go test -C zkit -count=1 ./...
- go test -C zkit -race ./...
- NATS_URL=<disposable-nats> go test -C zkit -race -count=1 ./messagebus
- MONGODB_URI=<disposable-mongo> go test -C zkit -race -count=1 ./docstore
- go tool task lint
- git diff --check