### PR TITLE
test: fuzz parser safety boundaries

### DIFF
--- a/zkit/agent/shellpolicy/fuzz_test.go
+++ b/zkit/agent/shellpolicy/fuzz_test.go
@@ -1,0 +1,61 @@
+package shellpolicy_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zkit/agent/shellpolicy"
+)
+
+func FuzzUnixPolicyAnalysis(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"go test ./...",
+		"cd ..",
+		"printf x > result.txt",
+		"python3 -c 'print(1)'",
+		"cat <<'EOF' | python3\nprint(1)\nEOF",
+		"unterminated '",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, command string) {
+		if len(command) > 32<<10 {
+			t.Skip()
+		}
+
+		parser := shellpolicy.NewUnixParser()
+		firstIR, firstErr := parser.Parse(command)
+		secondIR, secondErr := parser.Parse(command)
+		if !reflect.DeepEqual(firstIR, secondIR) {
+			t.Fatalf("Parse is not deterministic: first=%#v second=%#v", firstIR, secondIR)
+		}
+		if (firstErr == nil) != (secondErr == nil) {
+			t.Fatalf("Parse error presence is not deterministic: first=%v second=%v", firstErr, secondErr)
+		}
+
+		decision := shellpolicy.NewPolicyEngine().Decide(firstIR)
+		if firstErr != nil && !decision.IsBlocked {
+			t.Fatalf("syntax error did not fail closed: %v", firstErr)
+		}
+
+		firstTargets, firstTargetErr := shellpolicy.WriteTargets(command)
+		secondTargets, secondTargetErr := shellpolicy.WriteTargets(command)
+		if !reflect.DeepEqual(firstTargets, secondTargets) {
+			t.Fatalf("WriteTargets is not deterministic: first=%q second=%q", firstTargets, secondTargets)
+		}
+		if (firstTargetErr == nil) != (secondTargetErr == nil) {
+			t.Fatalf("WriteTargets error presence is not deterministic: first=%v second=%v", firstTargetErr, secondTargetErr)
+		}
+
+		firstMutation, firstMutationErr := shellpolicy.UnscopedMutationCommand(command)
+		secondMutation, secondMutationErr := shellpolicy.UnscopedMutationCommand(command)
+		if firstMutation != secondMutation {
+			t.Fatalf("UnscopedMutationCommand is not deterministic: first=%q second=%q", firstMutation, secondMutation)
+		}
+		if (firstMutationErr == nil) != (secondMutationErr == nil) {
+			t.Fatalf("UnscopedMutationCommand error presence is not deterministic: first=%v second=%v", firstMutationErr, secondMutationErr)
+		}
+	})
+}

--- a/zkit/ai/llm/toolparse/fuzz_test.go
+++ b/zkit/ai/llm/toolparse/fuzz_test.go
@@ -1,0 +1,54 @@
+package toolparse_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zkit/ai/llm/toolparse"
+)
+
+func FuzzParseArtifact(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"plain prose",
+		`<tool_calls>[{"name":"read","arguments":{"path":"README.md"}}]</tool_calls>`,
+		`{"tool_calls":[{"id":"call-1","type":"function","function":{"name":"write","arguments":"{\"path\":\"x\"}"}}]}`,
+		"```json\n[{\"name\":\"grep\",\"arguments\":{\"pattern\":\"x\"}}]\n```",
+		`<tool_calls>[{"name":"broken","arguments":{"x":1}]`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 64<<10 {
+			t.Skip()
+		}
+
+		first := toolparse.ParseArtifact(input)
+		second := toolparse.ParseArtifact(input)
+		if !reflect.DeepEqual(first, second) {
+			t.Fatalf("ParseArtifact is not deterministic: first=%#v second=%#v", first, second)
+		}
+		if !first.HighConfidence {
+			return
+		}
+
+		ids := make(map[string]struct{}, len(first.Calls))
+		for _, call := range first.Calls {
+			if call.ID == "" {
+				t.Fatal("high-confidence call has an empty ID")
+			}
+			if _, duplicate := ids[call.ID]; duplicate {
+				t.Fatalf("high-confidence calls contain duplicate ID %q", call.ID)
+			}
+			ids[call.ID] = struct{}{}
+			if call.Function.Name == "" {
+				t.Fatal("high-confidence call has an empty function name")
+			}
+			if !json.Valid([]byte(call.Function.Arguments)) {
+				t.Fatalf("high-confidence call arguments are not valid JSON: %q", call.Function.Arguments)
+			}
+		}
+	})
+}

--- a/zkit/ai/llm/toolparse/testdata/fuzz/FuzzParseArtifact/275948279cd960ff
+++ b/zkit/ai/llm/toolparse/testdata/fuzz/FuzzParseArtifact/275948279cd960ff
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\"tool_calls\"\"name\":\"0\"\"arguments\":0000")

--- a/zkit/ai/llm/toolparse/toolparse.go
+++ b/zkit/ai/llm/toolparse/toolparse.go
@@ -342,13 +342,14 @@ func recoverLooseToolCalls(content string) []llm.ToolCall {
 				i = strEnd
 				continue
 			}
-			if name != "" {
+			arguments := normalizeArguments(json.RawMessage(args))
+			if name != "" && json.Valid([]byte(arguments)) {
 				calls = append(calls, llm.ToolCall{
 					ID:   id,
 					Type: toolCallTypeFunction,
 					Function: llm.ToolCallFunction{
 						Name:      name,
-						Arguments: normalizeArguments(json.RawMessage(args)),
+						Arguments: arguments,
 					},
 				})
 			}

--- a/zkit/ai/tools/code/fuzz_test.go
+++ b/zkit/ai/tools/code/fuzz_test.go
@@ -1,0 +1,143 @@
+package code_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zkit/ai/tools"
+	"github.com/zarldev/zarlmono/zkit/ai/tools/code"
+)
+
+func FuzzApplyPatchSafety(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"*** Begin Patch\n*** End Patch\n",
+		"*** Begin Patch\n*** Add File: added.txt\n+hello\n*** End Patch\n",
+		"*** Begin Patch\n*** Update File: seed.txt\n@@\n-seed\n+changed\n*** End Patch\n",
+		"*** Begin Patch\n*** Add File: ../outside.txt\n+escaped\n*** End Patch\n",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, patch string) {
+		if len(patch) > 32<<10 {
+			t.Skip()
+		}
+
+		if got, again := code.PatchPaths(patch), code.PatchPaths(patch); !reflect.DeepEqual(got, again) {
+			t.Fatalf("PatchPaths is not deterministic: first=%q second=%q", got, again)
+		}
+		if got, again := code.PatchExistingPaths(patch), code.PatchExistingPaths(patch); !reflect.DeepEqual(got, again) {
+			t.Fatalf("PatchExistingPaths is not deterministic: first=%q second=%q", got, again)
+		}
+
+		base := t.TempDir()
+		root := filepath.Join(base, "workspace")
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatalf("create workspace: %v", err)
+		}
+		seedPath := filepath.Join(root, "seed.txt")
+		if err := os.WriteFile(seedPath, []byte("seed\n"), 0o644); err != nil {
+			t.Fatalf("seed workspace: %v", err)
+		}
+		outsidePath := filepath.Join(base, "outside.txt")
+		if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o644); err != nil {
+			t.Fatalf("seed outside sentinel: %v", err)
+		}
+		workspace, err := code.NewWorkspace(root)
+		if err != nil {
+			t.Fatalf("NewWorkspace: %v", err)
+		}
+		result, err := code.NewApplyPatchTool(workspace).Execute(t.Context(), tools.ToolCall{
+			ID:        "fuzz",
+			Arguments: tools.ToolParameters{"patch": patch},
+		})
+		if err != nil {
+			t.Fatalf("Execute returned transport error: %v", err)
+		}
+
+		outside, err := os.ReadFile(outsidePath)
+		if err != nil {
+			t.Fatalf("read outside sentinel: %v", err)
+		}
+		if string(outside) != "outside\n" {
+			t.Fatalf("patch mutated outside workspace: %q", outside)
+		}
+		if result.Success {
+			return
+		}
+		seed, err := os.ReadFile(seedPath)
+		if err != nil {
+			t.Fatalf("failed patch removed seed file: %v", err)
+		}
+		if string(seed) != "seed\n" {
+			t.Fatalf("failed patch partially mutated seed file: %q", seed)
+		}
+	})
+}
+
+func FuzzHashlineEditSafety(f *testing.F) {
+	f.Add("seed.txt", 1, "bad", "replace", "replacement")
+	f.Add("../outside.txt", 1, "bad", "replace", "escaped")
+	f.Add("seed.txt", -1, "", "delete", "")
+	f.Add("seed.txt", 1, "bad", "unknown", "x")
+
+	f.Fuzz(func(t *testing.T, path string, startLine int, startHash, mode, replacement string) {
+		if len(path)+len(startHash)+len(mode)+len(replacement) > 32<<10 {
+			t.Skip()
+		}
+
+		base := t.TempDir()
+		root := filepath.Join(base, "workspace")
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatalf("create workspace: %v", err)
+		}
+		seedPath := filepath.Join(root, "seed.txt")
+		if err := os.WriteFile(seedPath, []byte("seed\nsecond\n"), 0o644); err != nil {
+			t.Fatalf("seed workspace: %v", err)
+		}
+		outsidePath := filepath.Join(base, "outside.txt")
+		if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o644); err != nil {
+			t.Fatalf("seed outside sentinel: %v", err)
+		}
+		workspace, err := code.NewWorkspace(root)
+		if err != nil {
+			t.Fatalf("NewWorkspace: %v", err)
+		}
+		result, err := code.NewEditFileHLTool(workspace).Execute(t.Context(), tools.ToolCall{
+			ID: "fuzz",
+			Arguments: tools.ToolParameters{
+				"path": path,
+				"edits": []any{map[string]any{
+					"start_line": startLine,
+					"start_hash": startHash,
+					"mode":       mode,
+					"new_string": replacement,
+				}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Execute returned transport error: %v", err)
+		}
+
+		outside, err := os.ReadFile(outsidePath)
+		if err != nil {
+			t.Fatalf("read outside sentinel: %v", err)
+		}
+		if string(outside) != "outside\n" {
+			t.Fatalf("edit mutated outside workspace: %q", outside)
+		}
+		if result.Success {
+			return
+		}
+		seed, err := os.ReadFile(seedPath)
+		if err != nil {
+			t.Fatalf("failed edit removed seed file: %v", err)
+		}
+		if string(seed) != "seed\nsecond\n" {
+			t.Fatalf("failed edit partially mutated seed file: %q", seed)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add bounded fuzz targets for tool-call recovery, patch/hashline mutation safety, and shell-policy analysis
- assert deterministic parsing, atomic failed writes, and workspace confinement
- retain a discovered malformed tool-call regression corpus
- reject invalid recovered argument JSON instead of promoting it as executable

## Verification
- ordinary and race tests for all three packages
- 3-second fuzz smoke for each target
- go tool task lint
- test-policy gate
- git diff --check