### PR TITLE
test: cover zarlcode CLI behaviors

### DIFF
--- a/zarlcode/cli/askpass.go
+++ b/zarlcode/cli/askpass.go
@@ -48,13 +48,21 @@ func (c AskpassCommand) Execute(ctx context.Context, args []string, stdout, stde
 		return 2
 	}
 	defer conn.Close()
+	stopCancel := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopCancel()
 
 	if err := json.NewEncoder(conn).Encode(askpass.Request{Prompt: prompt}); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			err = cause
+		}
 		fmt.Fprintln(stderr, "zarlcode-askpass: send:", err)
 		return 2
 	}
 	var resp askpass.Response
 	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			err = cause
+		}
 		fmt.Fprintln(stderr, "zarlcode-askpass: recv:", err)
 		return 2
 	}

--- a/zarlcode/cli/askpass.go
+++ b/zarlcode/cli/askpass.go
@@ -7,21 +7,12 @@ package cli
 // To still let `sudo -A <cmd>` work, the interactive shell provides an
 // askpass helper that talks back to the shell process — which DOES have
 // the TTY — over a unix socket.
-//
-//	zarlcode --askpass "<prompt>"  — the helper mode. Sudo execs
-//	                                    this with the prompt as argv[1].
-//	                                    We connect to the socket whose
-//	                                    path is in env, send the prompt,
-//	                                    read the password back, and print
-//	                                    it to stdout (sudo's contract).
-//
-// The server side (the in-TUI password prompt that answers these
-// requests) is a TUI feature; it lives with the interactive shell.
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -29,17 +20,21 @@ import (
 	"github.com/zarldev/zarlmono/zarlcode/askpass"
 )
 
-// RunAskpassClient is the entry point for `zarlcode --askpass`.
-// Connects to the shell over the unix socket and pipes the password
-// back to sudo via stdout. Never returns to main(); calls os.Exit.
-func RunAskpassClient(args []string) {
-	os.Exit(runAskpassClient(args))
+// AskpassCommand executes the askpass socket protocol. Sock may be supplied by
+// an embedder; its zero value reads the production socket environment variable.
+type AskpassCommand struct {
+	Sock string
 }
 
-func runAskpassClient(args []string) int {
-	sock := os.Getenv(askpass.EnvSock)
+// Execute sends the requested prompt to the owning TUI and writes the returned
+// password to stdout using sudo's one-line askpass protocol.
+func (c AskpassCommand) Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	sock := c.Sock
 	if sock == "" {
-		fmt.Fprintln(os.Stderr, "zarlcode-askpass: ZARLCODE_ASKPASS_SOCK is unset")
+		sock = os.Getenv(askpass.EnvSock)
+	}
+	if sock == "" {
+		fmt.Fprintln(stderr, "zarlcode-askpass: ZARLCODE_ASKPASS_SOCK is unset")
 		return 2
 	}
 	prompt := "Password:"
@@ -47,28 +42,31 @@ func runAskpassClient(args []string) int {
 		prompt = strings.TrimSpace(strings.Join(args, " "))
 	}
 
-	conn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", sock)
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", sock)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "zarlcode-askpass: dial:", err)
+		fmt.Fprintln(stderr, "zarlcode-askpass: dial:", err)
 		return 2
 	}
 	defer conn.Close()
 
 	if err := json.NewEncoder(conn).Encode(askpass.Request{Prompt: prompt}); err != nil {
-		fmt.Fprintln(os.Stderr, "zarlcode-askpass: send:", err)
+		fmt.Fprintln(stderr, "zarlcode-askpass: send:", err)
 		return 2
 	}
 	var resp askpass.Response
 	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
-		fmt.Fprintln(os.Stderr, "zarlcode-askpass: recv:", err)
+		fmt.Fprintln(stderr, "zarlcode-askpass: recv:", err)
 		return 2
 	}
 	if resp.Error != "" {
-		fmt.Fprintln(os.Stderr, "zarlcode-askpass:", resp.Error)
+		fmt.Fprintln(stderr, "zarlcode-askpass:", resp.Error)
 		return 2
 	}
-	// sudo reads exactly one line from stdout — no trailing newline
-	// quirks needed; Println adds the newline sudo expects.
-	fmt.Fprintln(os.Stdout, resp.Password)
+	fmt.Fprintln(stdout, resp.Password)
 	return 0
+}
+
+// RunAskpassClient is the entry point for `zarlcode --askpass`.
+func RunAskpassClient(args []string) {
+	os.Exit((AskpassCommand{}).Execute(context.Background(), args, os.Stdout, os.Stderr))
 }

--- a/zarlcode/cli/askpass_unix_test.go
+++ b/zarlcode/cli/askpass_unix_test.go
@@ -4,7 +4,10 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net"
 	"path/filepath"
 	"strings"
@@ -60,6 +63,42 @@ func TestAskpassCommandProtocol(t *testing.T) {
 			t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
 		}
 	})
+}
+
+func TestAskpassCommandCancellationAfterConnect(t *testing.T) {
+	requestRead := make(chan struct{})
+	sock := serveAskpass(t, func(conn net.Conn) error {
+		var req askpass.Request
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			return err
+		}
+		close(requestRead)
+		var one [1]byte
+		_, err := conn.Read(one[:])
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancelled := make(chan struct{})
+	go func() {
+		defer close(cancelled)
+		select {
+		case <-requestRead:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := (cli.AskpassCommand{Sock: sock}).Execute(ctx, nil, &stdout, &stderr)
+	cancel()
+	<-cancelled
+	if code != 2 || stdout.String() != "" || stderr.String() != "zarlcode-askpass: recv: context canceled\n" {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
 }
 
 func TestAskpassCommandRequiresSocket(t *testing.T) {

--- a/zarlcode/cli/askpass_unix_test.go
+++ b/zarlcode/cli/askpass_unix_test.go
@@ -1,0 +1,103 @@
+//go:build unix
+
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zarlcode/askpass"
+	"github.com/zarldev/zarlmono/zarlcode/cli"
+)
+
+func TestAskpassCommandProtocol(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var got askpass.Request
+		sock := serveAskpass(t, func(conn net.Conn) error {
+			if err := json.NewDecoder(conn).Decode(&got); err != nil {
+				return err
+			}
+			return json.NewEncoder(conn).Encode(askpass.Response{Password: "secret value"})
+		})
+		code, stdout, stderr := executeAskpass(t, cli.AskpassCommand{Sock: sock}, " sudo ", " password: ")
+		if code != 0 || stdout != "secret value\n" || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+		if got.Prompt != "sudo   password:" {
+			t.Fatalf("prompt = %q", got.Prompt)
+		}
+	})
+
+	t.Run("malformed reply", func(t *testing.T) {
+		sock := serveAskpass(t, func(conn net.Conn) error {
+			var req askpass.Request
+			if err := json.NewDecoder(conn).Decode(&req); err != nil {
+				return err
+			}
+			_, err := conn.Write([]byte("not-json\n"))
+			return err
+		})
+		code, stdout, stderr := executeAskpass(t, cli.AskpassCommand{Sock: sock})
+		if code != 2 || stdout != "" || !strings.Contains(stderr, "zarlcode-askpass: recv:") {
+			t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+	})
+
+	t.Run("server cancellation", func(t *testing.T) {
+		sock := serveAskpass(t, func(conn net.Conn) error {
+			var req askpass.Request
+			if err := json.NewDecoder(conn).Decode(&req); err != nil {
+				return err
+			}
+			return json.NewEncoder(conn).Encode(askpass.Response{Error: "cancelled"})
+		})
+		code, stdout, stderr := executeAskpass(t, cli.AskpassCommand{Sock: sock})
+		if code != 2 || stdout != "" || stderr != "zarlcode-askpass: cancelled\n" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+	})
+}
+
+func TestAskpassCommandRequiresSocket(t *testing.T) {
+	t.Setenv(askpass.EnvSock, "")
+	code, stdout, stderr := executeAskpass(t, cli.AskpassCommand{})
+	if code != 2 || stdout != "" || !strings.Contains(stderr, "ZARLCODE_ASKPASS_SOCK is unset") {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func executeAskpass(t *testing.T, cmd cli.AskpassCommand, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := cmd.Execute(t.Context(), args, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func serveAskpass(t *testing.T, handle func(net.Conn) error) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "askpass.sock")
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			err = handle(conn)
+			_ = conn.Close()
+		}
+		done <- err
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		if err := <-done; err != nil {
+			t.Errorf("askpass server: %v", err)
+		}
+	})
+	return sock
+}

--- a/zarlcode/cli/init_test.go
+++ b/zarlcode/cli/init_test.go
@@ -1,0 +1,63 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zarlcode/cli"
+)
+
+func TestRunInitCreatesAndPreservesHome(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	var first bytes.Buffer
+	if code := cli.RunInit(&first); code != 0 {
+		t.Fatalf("RunInit() exit = %d, output = %q", code, first.String())
+	}
+	root := filepath.Join(homeDir, ".zarlcode")
+	for _, name := range []string{"skills", "tools", "hooks"} {
+		info, err := os.Stat(filepath.Join(root, name))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("%s directory: info=%v err=%v", name, info, err)
+		}
+	}
+	if !strings.Contains(first.String(), "zarlcode home at "+root) || !strings.Contains(first.String(), "created: skills/, tools/, hooks/") {
+		t.Fatalf("first output = %q", first.String())
+	}
+
+	marker := filepath.Join(root, "skills", "mine.md")
+	want := []byte("preserve exactly\n")
+	if err := os.WriteFile(marker, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var second bytes.Buffer
+	if code := cli.RunInit(&second); code != 0 {
+		t.Fatalf("second RunInit() exit = %d, output = %q", code, second.String())
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("preserved file = %q, %v", got, err)
+	}
+	if strings.Contains(second.String(), "created:") || !strings.Contains(second.String(), "existed: skills/, tools/, hooks/") {
+		t.Fatalf("second output = %q", second.String())
+	}
+}
+
+func TestRunInitReturnsFailureWithoutWritingOutput(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".zarlcode"), []byte("conflict"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if code := cli.RunInit(&out); code != 1 {
+		t.Fatalf("RunInit() exit = %d, want 1", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("RunInit() output = %q, want empty", out.String())
+	}
+}

--- a/zarlcode/cli/keys.go
+++ b/zarlcode/cli/keys.go
@@ -13,47 +13,75 @@ import (
 	"github.com/zarldev/zarlmono/zkit/vault"
 )
 
-// RunKeys is the entry point for `zarlcode keys ...`.
-// It opens the store + vault (auto-generating the master key on
-// first use) but skips the TUI, the provider build, and every other
-// startup step — the whole point of the subcommand is to populate
-// the vault while no provider can yet launch.
-//
-// Synopsis:
-//
-//	zarlcode keys                       # alias for `list`
-//	zarlcode keys list
-//	zarlcode keys set <provider> <key>  # encrypts + stores globally
-//	zarlcode keys delete <provider>     # removes the global entry
-//	zarlcode keys oauth <provider>      # runs the OAuth flow for a
-//	                                       # provider (currently only
-//	                                       # openai-codex), persisting
-//	                                       # the resulting token bundle
-//	                                       # in the same encrypted vault
-//	                                       # as plain api keys.
-//
-// "Globally" means workspace="" in the api_keys table; every
-// workspace inherits via the store's built-in fallback.
+// OAuthLoginFunc dispatches an interactive OAuth login for a provider.
+type OAuthLoginFunc func(context.Context, *prefs.Service, string, io.Reader, io.Writer) error
+
+// KeysCommand executes key-management commands against an explicitly supplied
+// preference service. Stdin and OAuthLogin are optional environment overrides;
+// their zero values select the production process input and OAuth dispatcher.
+type KeysCommand struct {
+	Service    *prefs.Service
+	Stdin      io.Reader
+	OAuthLogin OAuthLoginFunc
+}
+
+// Execute runs a keys command and returns its process exit code.
+func (c KeysCommand) Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	oauthLogin := c.OAuthLogin
+	if oauthLogin == nil {
+		oauthLogin = oauth.RunLogin
+	}
+
+	cmd := cmdList
+	if len(args) > 0 {
+		cmd = args[0]
+	}
+	switch cmd {
+	case cmdList:
+		return keysList(ctx, c.Service, stdout, stderr)
+	case subcmdSet:
+		if len(args) < 3 {
+			fmt.Fprintln(stderr, "usage: zarlcode keys set <provider> <key>")
+			return 2
+		}
+		return keysSet(ctx, c.Service, args[1], strings.Join(args[2:], " "), stdout, stderr)
+	case subcmdDelete, "rm":
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "usage: zarlcode keys delete <provider>")
+			return 2
+		}
+		return keysDelete(ctx, c.Service, args[1], stdout, stderr)
+	case "oauth":
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "usage: zarlcode keys oauth <provider>")
+			return 2
+		}
+		return keysOAuth(ctx, c.Service, oauthLogin, args[1], stdin, stdout, stderr)
+	case "protect":
+		return keysProtect(ctx, c.Service, args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown subcommand %q (want list | set | delete | oauth | protect)\n", cmd)
+		return 2
+	}
+}
+
+// RunKeys is the entry point for `zarlcode keys ...`. It opens only the
+// preference store and any vault required by the requested operation.
 func RunKeys(args []string, stdout io.Writer) int {
 	ctx := context.Background()
-	// db.Open creates ~/.zarlcode (MkdirAll) on first use, so we don't
-	// pre-seed the full home here — `zarlcode keys` only needs the
-	// state.db to exist, not skills/ / tools/ / hooks/ (those are
-	// seeded by `zarlcode init` and the implicit TUI first-run).
 	store, err := db.Open(ctx, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "store:", err)
 		return 1
 	}
 	defer store.Close()
-	// CLI subcommand has no workspace context, so the service is
-	// constructed with wsRoot="" — only global-scope operations are
-	// valid. Workspace ops would fail with prefs.ErrNoWorkspace anyway, but
-	// the explicit empty signals "we don't have a workspace here" to
-	// any future caller that might be tempted to add one.
 	svc := prefs.NewService(store, nil, "")
 
-	cmd := "list"
+	cmd := cmdList
 	if len(args) > 0 {
 		cmd = args[0]
 	}
@@ -65,39 +93,13 @@ func RunKeys(args []string, stdout io.Writer) int {
 		}
 		svc.SetVault(v)
 	}
-	switch cmd {
-	case "list":
-		return keysList(ctx, svc, stdout)
-	case subcmdSet:
-		if len(args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: zarlcode keys set <provider> <key>")
-			return 2
-		}
-		return keysSet(ctx, svc, args[1], strings.Join(args[2:], " "), stdout)
-	case subcmdDelete, "rm":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: zarlcode keys delete <provider>")
-			return 2
-		}
-		return keysDelete(ctx, svc, args[1], stdout)
-	case "oauth":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: zarlcode keys oauth <provider>")
-			return 2
-		}
-		return keysOAuth(ctx, svc, args[1], os.Stdin, stdout)
-	case "protect":
-		return keysProtect(ctx, svc, args[1:], stdout)
-	default:
-		fmt.Fprintf(os.Stderr, "unknown subcommand %q (want list | set | delete | oauth | protect)\n", cmd)
-		return 2
-	}
+	return (KeysCommand{Service: svc}).Execute(ctx, args, stdout, os.Stderr)
 }
 
 func needsKeysVault(ctx context.Context, svc *prefs.Service, cmd string) bool {
 	switch cmd {
 	case "protect":
-		return false // the subcommand opens the vault only for on/off as needed.
+		return false
 	case subcmdSet, "oauth":
 		mode, err := svc.CredentialProtection(ctx)
 		return err == nil && mode == prefs.CredentialProtectionPassphrase
@@ -106,71 +108,77 @@ func needsKeysVault(ctx context.Context, svc *prefs.Service, cmd string) bool {
 	}
 }
 
-// keysOAuth runs the interactive OAuth flow for a provider (only
-// openai-codex today) and writes the resulting credential through the
-// [prefs.Service] at [prefs.ScopeGlobal] — same scope plain api keys use,
-// just routed through the shared service so the audit story stays
-// uniform.
-func keysOAuth(ctx context.Context, svc *prefs.Service, provider string, stdin io.Reader, stdout io.Writer) int {
+func keysOAuth(ctx context.Context, svc *prefs.Service, login OAuthLoginFunc, provider string, stdin io.Reader, stdout, stderr io.Writer) int {
 	provider = strings.ToLower(strings.TrimSpace(provider))
-	if err := oauth.RunLogin(ctx, svc, provider, stdin, stdout); err != nil {
-		fmt.Fprintln(os.Stderr, "oauth:", err)
+	if provider == "" {
+		fmt.Fprintln(stderr, "provider name is empty")
+		return 2
+	}
+	if err := login(ctx, svc, provider, stdin, stdout); err != nil {
+		fmt.Fprintln(stderr, "oauth:", err)
 		return 1
 	}
 	return 0
 }
 
-func keysList(ctx context.Context, svc *prefs.Service, w io.Writer) int {
+func keysList(ctx context.Context, svc *prefs.Service, stdout, stderr io.Writer) int {
 	providers, err := svc.ListKeys(ctx, prefs.ScopeGlobal)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "list:", err)
+		fmt.Fprintln(stderr, "list:", err)
 		return 1
 	}
 	if len(providers) == 0 {
-		fmt.Fprintln(w, "no api keys stored (try: zarlcode keys set <provider> <key>)")
+		fmt.Fprintln(stdout, "no api keys stored (try: zarlcode keys set <provider> <key>)")
 		return 0
 	}
-	fmt.Fprintln(w, "stored api keys (global scope):")
-	for _, p := range providers {
-		fmt.Fprintf(w, "  - %s\n", p)
+	fmt.Fprintln(stdout, "stored api keys (global scope):")
+	for _, provider := range providers {
+		fmt.Fprintf(stdout, "  - %s\n", provider)
 	}
 	return 0
 }
 
-func keysSet(ctx context.Context, svc *prefs.Service, provider, key string, w io.Writer) int {
+func keysSet(ctx context.Context, svc *prefs.Service, provider, key string, stdout, stderr io.Writer) int {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	key = strings.TrimSpace(key)
 	if provider == "" {
-		fmt.Fprintln(os.Stderr, "provider name is empty")
+		fmt.Fprintln(stderr, "provider name is empty")
 		return 2
 	}
 	if key == "" {
-		fmt.Fprintln(os.Stderr, "key is empty")
+		fmt.Fprintln(stderr, "key is empty")
 		return 2
 	}
 	if err := svc.SetKey(ctx, prefs.ScopeGlobal, provider, key); err != nil {
-		fmt.Fprintln(os.Stderr, "set:", err)
+		fmt.Fprintln(stderr, "set:", err)
 		return 1
 	}
-	fmt.Fprintf(w, "stored api key for %q globally — every workspace inherits via fallback\n", provider)
+	fmt.Fprintf(stdout, "stored api key for %q globally — every workspace inherits via fallback\n", provider)
 	return 0
 }
 
-func keysDelete(ctx context.Context, svc *prefs.Service, provider string, w io.Writer) int {
+func keysDelete(ctx context.Context, svc *prefs.Service, provider string, stdout, stderr io.Writer) int {
 	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		fmt.Fprintln(stderr, "provider name is empty")
+		return 2
+	}
 	if err := svc.DeleteKey(ctx, prefs.ScopeGlobal, provider); err != nil {
-		fmt.Fprintln(os.Stderr, "delete:", err)
+		fmt.Fprintln(stderr, "delete:", err)
 		return 1
 	}
-	fmt.Fprintf(w, "removed api key for %q from global scope\n", provider)
+	fmt.Fprintf(stdout, "removed api key for %q from global scope\n", provider)
 	return 0
 }
 
 // cmdStatus is the default/"show current state" subcommand shared by the
 // keys-protect and upgrade CLI verbs.
-const cmdStatus = "status"
+const (
+	cmdList   = "list"
+	cmdStatus = "status"
+)
 
-func keysProtect(ctx context.Context, svc *prefs.Service, args []string, w io.Writer) int {
+func keysProtect(ctx context.Context, svc *prefs.Service, args []string, stdout, stderr io.Writer) int {
 	cmd := cmdStatus
 	if len(args) > 0 {
 		cmd = strings.ToLower(strings.TrimSpace(args[0]))
@@ -179,29 +187,29 @@ func keysProtect(ctx context.Context, svc *prefs.Service, args []string, w io.Wr
 	case cmdStatus:
 		mode, err := svc.CredentialProtection(ctx)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "protect:", err)
+			fmt.Fprintln(stderr, "protect:", err)
 			return 1
 		}
-		fmt.Fprintf(w, "credential protection: %s\n", mode)
+		fmt.Fprintf(stdout, "credential protection: %s\n", mode)
 		return 0
 	case "on", "enable":
 		n, err := svc.EnableCredentialProtection(ctx, vault.TerminalPassphrase)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "protect on:", err)
+			fmt.Fprintln(stderr, "protect on:", err)
 			return 1
 		}
-		fmt.Fprintf(w, "credential protection enabled — encrypted %d key(s)\n", n)
+		fmt.Fprintf(stdout, "credential protection enabled — encrypted %d key(s)\n", n)
 		return 0
 	case "off", "disable":
 		n, err := svc.DisableCredentialProtection(ctx, vault.TerminalPassphrase)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "protect off:", err)
+			fmt.Fprintln(stderr, "protect off:", err)
 			return 1
 		}
-		fmt.Fprintf(w, "credential protection off — stored %d key(s) as plaintext\n", n)
+		fmt.Fprintf(stdout, "credential protection off — stored %d key(s) as plaintext\n", n)
 		return 0
 	default:
-		fmt.Fprintln(os.Stderr, "usage: zarlcode keys protect [status|on|off]")
+		fmt.Fprintln(stderr, "usage: zarlcode keys protect [status|on|off]")
 		return 2
 	}
 }

--- a/zarlcode/cli/keys_test.go
+++ b/zarlcode/cli/keys_test.go
@@ -1,0 +1,122 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zarlcode/cli"
+	"github.com/zarldev/zarlmono/zkit/prefs"
+)
+
+func TestKeysCommandSetListDeleteUsesGlobalScopeAndRedactsSecrets(t *testing.T) {
+	svc := prefs.NewService(openTestStore(t), nil, t.TempDir())
+	cmd := cli.KeysCommand{Service: svc}
+	secret := "sk-super-secret"
+
+	code, stdout, stderr := executeKeys(t, cmd, "set", " OpenAI ", " "+secret+" ")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "stored api key for \"openai\" globally") {
+		t.Fatalf("set: exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	assertRedacted(t, secret, stdout, stderr)
+	got, err := svc.GetKey(t.Context(), prefs.ScopeGlobal, "openai")
+	if err != nil || got != secret {
+		t.Fatalf("global key = %q, %v", got, err)
+	}
+	if _, err := svc.GetKey(t.Context(), prefs.ScopeWorkspace, "openai"); !errors.Is(err, prefs.ErrNotFound) {
+		t.Fatalf("workspace key error = %v, want ErrNotFound", err)
+	}
+
+	code, stdout, stderr = executeKeys(t, cmd, "list")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "stored api keys (global scope):\n  - openai\n") {
+		t.Fatalf("list: exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	assertRedacted(t, secret, stdout, stderr)
+
+	code, stdout, stderr = executeKeys(t, cmd, "delete", " OPENAI ")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "removed api key for \"openai\" from global scope") {
+		t.Fatalf("delete: exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	assertRedacted(t, secret, stdout, stderr)
+	if _, err := svc.GetKey(t.Context(), prefs.ScopeGlobal, "openai"); !errors.Is(err, prefs.ErrNotFound) {
+		t.Fatalf("global key after delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestKeysCommandProtectStatus(t *testing.T) {
+	cmd := cli.KeysCommand{Service: prefs.NewService(openTestStore(t), nil, "")}
+	for _, args := range [][]string{{"protect"}, {"protect", "status"}} {
+		code, stdout, stderr := executeKeys(t, cmd, args...)
+		if code != 0 || stdout != "credential protection: off\n" || stderr != "" {
+			t.Fatalf("%v: exit=%d stdout=%q stderr=%q", args, code, stdout, stderr)
+		}
+	}
+}
+
+func TestKeysCommandRejectsInvalidCommandsAndProviders(t *testing.T) {
+	cmd := cli.KeysCommand{Service: prefs.NewService(openTestStore(t), nil, "")}
+	cases := []struct {
+		args []string
+		code int
+		want string
+	}{
+		{[]string{"wat"}, 2, "unknown subcommand"},
+		{[]string{"set", " ", "secret"}, 2, "provider name is empty"},
+		{[]string{"set", "openai", " "}, 2, "key is empty"},
+		{[]string{"delete", " "}, 2, "provider name is empty"},
+		{[]string{"protect", "wat"}, 2, "usage: zarlcode keys protect"},
+		{[]string{"oauth", "unsupported-provider"}, 1, "is not supported"},
+	}
+	for _, tc := range cases {
+		code, stdout, stderr := executeKeys(t, cmd, tc.args...)
+		if code != tc.code || stdout != "" || !strings.Contains(stderr, tc.want) {
+			t.Errorf("%v: exit=%d stdout=%q stderr=%q", tc.args, code, stdout, stderr)
+		}
+		assertRedacted(t, "secret", stdout, stderr)
+	}
+}
+
+func TestKeysCommandDispatchesOAuthWithoutLiveProvider(t *testing.T) {
+	svc := prefs.NewService(openTestStore(t), nil, "")
+	stdin := strings.NewReader("callback input")
+	var gotProvider, gotInput string
+	var gotService *prefs.Service
+	login := func(_ context.Context, service *prefs.Service, provider string, in io.Reader, out io.Writer) error {
+		gotService = service
+		gotProvider = provider
+		data, err := io.ReadAll(in)
+		if err != nil {
+			return err
+		}
+		gotInput = string(data)
+		_, err = io.WriteString(out, "oauth dispatched\n")
+		return err
+	}
+	cmd := cli.KeysCommand{Service: svc, Stdin: stdin, OAuthLogin: login}
+	code, stdout, stderr := executeKeys(t, cmd, "oauth", " OPENAI-CODEX ")
+	if code != 0 || stdout != "oauth dispatched\n" || stderr != "" {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if gotService != svc || gotProvider != "openai-codex" || gotInput != "callback input" {
+		t.Fatalf("dispatch: service=%p provider=%q input=%q", gotService, gotProvider, gotInput)
+	}
+}
+
+func executeKeys(t *testing.T, cmd cli.KeysCommand, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := cmd.Execute(t.Context(), args, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func assertRedacted(t *testing.T, secret string, outputs ...string) {
+	t.Helper()
+	for _, output := range outputs {
+		if strings.Contains(output, secret) {
+			t.Fatalf("secret leaked in output %q", output)
+		}
+	}
+}

--- a/zarlcode/cli/prompt.go
+++ b/zarlcode/cli/prompt.go
@@ -1,16 +1,19 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 )
 
-// ResolvePrompt loads the task prompt from whichever source the
-// invocation provided: --prompt-text wins when set, --prompt-file is
-// the SWE-bench-shaped form. Returning ("", nil) means the user
-// asked for no prompt — bail with the bad-invocation exit code.
+// ResolvePrompt loads a headless task prompt from either an inline value or a
+// file. Supplying both sources is an invocation error; an empty source resolves
+// to an empty prompt.
 func ResolvePrompt(promptFile, promptText string) (string, error) {
+	if promptFile != "" && strings.TrimSpace(promptText) != "" {
+		return "", errors.New("prompt-file and prompt-text are mutually exclusive")
+	}
 	if strings.TrimSpace(promptText) != "" {
 		return promptText, nil
 	}

--- a/zarlcode/cli/prompt_test.go
+++ b/zarlcode/cli/prompt_test.go
@@ -1,0 +1,63 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zarldev/zarlmono/zarlcode/cli"
+)
+
+func TestResolvePromptSources(t *testing.T) {
+	t.Run("inline", func(t *testing.T) {
+		got, err := cli.ResolvePrompt("", "  keep spacing  ")
+		if err != nil || got != "  keep spacing  " {
+			t.Fatalf("ResolvePrompt() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "prompt.txt")
+		if err := os.WriteFile(path, []byte("from file\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := cli.ResolvePrompt(path, "")
+		if err != nil || got != "from file\n" {
+			t.Fatalf("ResolvePrompt() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := cli.ResolvePrompt("", " \t ")
+		if err != nil || got != "" {
+			t.Fatalf("ResolvePrompt() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.txt")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := cli.ResolvePrompt(path, "")
+		if err != nil || got != "" {
+			t.Fatalf("ResolvePrompt() = %q, %v", got, err)
+		}
+	})
+}
+
+func TestResolvePromptRejectsMultipleSources(t *testing.T) {
+	_, err := cli.ResolvePrompt("prompt.txt", "inline")
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("ResolvePrompt() error = %v", err)
+	}
+}
+
+func TestResolvePromptReportsReadErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.txt")
+	_, err := cli.ResolvePrompt(path, "")
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("ResolvePrompt() error = %v", err)
+	}
+}

--- a/zarlcode/main.go
+++ b/zarlcode/main.go
@@ -77,7 +77,7 @@ func Main() {
 	promptText := flag.String(
 		"prompt-text",
 		"",
-		"inline task prompt (for --headless; wins over --prompt-file when both set)",
+		"inline task prompt (for --headless; mutually exclusive with --prompt-file)",
 	)
 	promptProfileFlag := flag.String(
 		"prompt-profile",


### PR DESCRIPTION
## Summary
- cover prompt resolution and init idempotence with isolated filesystem state
- add injectable askpass and key-management command seams
- exercise socket protocol, global key scope, redaction, protection, and OAuth dispatch
- reject mutually exclusive headless prompt inputs explicitly

## Verification
- go test -C zarlcode -race -count=1 ./cli
- go tool task check
- go tool task lint
- go tool task race
- test-policy gate
- git diff --check