### PR TITLE
refactor: extract SWE-bench CLI configuration

### DIFF
--- a/swebench-eval/cmd/eval/main.go
+++ b/swebench-eval/cmd/eval/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/zarldev/zarlmono/swebench-eval/db"
+	"github.com/zarldev/zarlmono/swebench-eval/evalconfig"
 	"github.com/zarldev/zarlmono/swebench-eval/harness"
 	"github.com/zarldev/zarlmono/swebench-eval/report"
 	"github.com/zarldev/zarlmono/swebench-eval/runner"
@@ -54,100 +55,40 @@ func main() {
 // close, ctx cancel) always runs: errors return up to main, which is the
 // single place that exits the process.
 func run() error {
-	tasksPath := flag.String("tasks", "", "path to SWE-bench JSONL or Parquet task file (required)")
-	driversFlag := flag.String("drivers", "zarlcode", "comma-separated list of drivers to run (zarlcode)")
-	ablationsFlag := flag.String("ablations", "", "comma-separated zarlcode guardrail-ablation arms, or \"all\" (baseline, no-shell, no-skill-hint, no-decompose, no-fanout, no-test-edit, no-improvement, judge); each arm runs as its own driver")
-	langFlag := flag.String("languages", "", "comma-separated language filter (empty = all)")
-	sampleN := flag.Int("sample", 0, "stratified sample size (0 = run all matching specs)")
-	envFile := flag.String("env", "", "path to .env loaded before provider construction (carries per-backend URL/key knobs)")
-	zarlcodeProvider := flag.String("zarlcode-provider", "", "pin zarlcode's backend (registry name: llamacpp, openai-codex, gemini, claude-code, …); empty = registry default (llamacpp)")
-	zarlcodeModel := flag.String("zarlcode-model", "", "pin zarlcode's model (e.g. gpt-5.5, qwen3.6-35b-a3b-mtp); empty = provider's default model")
-	zarlcodeCodexEffort := flag.String("zarlcode-codex-effort", "", "codex_reasoning_effort when provider is openai-codex (low/medium/high/xhigh/max)")
-	llamacppResetURL := flag.String("llamacpp-reset-url", "", "POSTed before each task to flush local llama-server's KV cache slot; e.g. http://localhost:8081/slots/0?action=erase (requires --slot-save-path on the server)")
-	allowRemoteResetURL := flag.Bool("allow-remote-reset-url", false, "permit a non-loopback --llamacpp-reset-url (default: loopback only, to avoid SSRF via a misconfigured URL)")
-	stateDB := flag.String("state-db", "", "path to zarlcode state.db — vault + custom-provider rows (empty = $HOME/.zarlcode/state.db)")
-	taskTimeout := flag.Duration("task-timeout", 5*time.Minute, "wall-clock budget per (task, driver)")
-	maxIter := flag.Int("max-iter", 0, "cap the agent loop's iterations (0 = loop default)")
-	toolConcurrency := flag.Int("tool-concurrency", 0, "cap concurrent tool dispatch per iteration (0 = sequential)")
-	contextWindow := flag.Int("context-window", 0, "compactor context-window size in tokens (0 = 32768)")
-	zarlcodeStreamIdle := flag.Duration("zarlcode-stream-idle", 0, "zarlcode stream-idle watchdog: gap between chunks before the stall detector fires (0 = coderunner default 90s); raise for slow-prefill local models")
-	zarlcodeIterationTimeout := flag.Duration("zarlcode-iteration-timeout", 0, "zarlcode per-iteration wall-clock backstop (0 = coderunner default 5m); raise for slow-prefill local models")
-	zarlcodeDeadlineGrace := flag.Duration("zarlcode-deadline-grace", 0, "time before the task deadline at which the wrap-up nudge fires (0 = disabled); give the model a last-chance to commit before the task-timeout cancels it")
-	zarlcodeVerifiedAttempts := flag.Int("zarlcode-verified-attempts", 0, "enable zarlcode harness re-drive with SWE-bench verifier; values >1 cap attempts, 0/1 = trust terminal reason")
-	zarlcodeVerifyWorkers := flag.Int("zarlcode-verify-workers", 1, "SWE-bench evaluator workers for per-attempt zarlcode verification")
-	zarlcodeVerifyWorkDir := flag.String("zarlcode-verify-workdir", "", "directory for per-attempt zarlcode verification logs (empty = tempdir per attempt)")
-	zarlcodeVerifyTimeout := flag.Duration("zarlcode-verify-timeout", 0, "per-attempt SWE-bench verifier timeout, independent of the agent task timeout (0 = 30m)")
-	zarlcodeThreadTranscript := flag.Bool("zarlcode-thread-transcript", false, "verified re-drives carry the full prior transcript (needs a large --context-window); default re-drives with verifier feedback only")
-	zarlcodeTranscriptDir := flag.String("zarlcode-transcript-dir", "", "persist each task's full agent transcript to <dir>/<instance_id>.json for post-hoc debugging (empty = disabled)")
-	concurrency := flag.Int("concurrency", 1, "parallel (task, driver) invocations")
-	worktreeDir := flag.String("worktree-dir", "", "where to materialize worktrees (empty = a fresh tempdir)")
-	cloneCache := flag.String("clone-cache", "", "optional --reference clone cache directory")
-	keepWorktrees := flag.Bool("keep-worktrees", false, "leave worktrees on disk after the run for post-hoc inspection")
-	score := flag.Bool("score", false, "after the harness loop, invoke SWE-bench's evaluator on each driver's diffs and report resolved/unresolved")
-	scoreDataset := flag.String("score-dataset", "SWE-bench/SWE-bench_Multilingual", "dataset name passed to the SWE-bench evaluator")
-	scoreWorkers := flag.Int("score-workers", 4, "SWE-bench evaluator --max_workers")
-	scoreWorkDir := flag.String("score-workdir", "", "directory for the evaluator's predictions + logs (empty = a fresh tempdir)")
-	scorePython := flag.String("score-python", "", "python interpreter that has the swebench package importable (empty = python3 on PATH; typical: a venv's bin/python)")
-	dbPath := flag.String("db", "", "path to swebench-eval sqlite (empty = $HOME/.zarlcode/swebench-eval.db)")
-	runID := flag.String("run-id", "", "explicit run id (empty = a generated uuid)")
-	runNotes := flag.String("run-notes", "", "free-form notes to attach to the run row — eg. 'after decompose advisory refactor'")
-	versionFlag := flag.Bool("version", false, "print the build version and exit")
-	flag.Parse()
-	if *versionFlag {
+	cfg, err := evalconfig.Parse(flag.CommandLine, os.Args[1:])
+	if err != nil {
+		return err
+	}
+	if cfg.Version {
 		fmt.Fprintln(os.Stdout, version.String())
 		return nil
 	}
 
-	if *tasksPath == "" {
+	if cfg.Input.Tasks == "" {
 		fmt.Fprintln(os.Stderr, "--tasks is required")
 		os.Exit(2)
 	}
 
-	specs, err := task.LoadAny(*tasksPath)
+	specs, err := task.LoadAny(cfg.Input.Tasks)
 	if err != nil {
 		log.Fatalf("load tasks: %v", err)
 	}
-	if *langFlag != "" {
-		langs := strings.Split(*langFlag, ",")
-		specs = task.FilterByLanguage(specs, langs...)
+	if languages := cfg.Input.LanguageFilter(); len(languages) > 0 {
+		specs = task.FilterByLanguage(specs, languages...)
 	}
-	if *sampleN > 0 {
-		specs = task.Sample(specs, *sampleN)
+	if cfg.Input.Sample > 0 {
+		specs = task.Sample(specs, cfg.Input.Sample)
 	}
 	if len(specs) == 0 {
 		fmt.Fprintln(os.Stderr, "no tasks matched the given filters")
 		os.Exit(2)
 	}
 
-	ablations, err := harness.AblationArms(*ablationsFlag)
+	ablations, err := cfg.Input.Ablations()
 	if err != nil {
 		return fmt.Errorf("--ablations: %w", err)
 	}
-	drivers, err := buildDrivers(driverBuildOpts{
-		spec:                *driversFlag,
-		ablations:           ablations,
-		envFile:             *envFile,
-		stateDB:             *stateDB,
-		maxIter:             *maxIter,
-		toolConcurrency:     *toolConcurrency,
-		contextWindow:       *contextWindow,
-		streamIdle:          *zarlcodeStreamIdle,
-		iterationTimeout:    *zarlcodeIterationTimeout,
-		deadlineGrace:       *zarlcodeDeadlineGrace,
-		provider:            *zarlcodeProvider,
-		model:               *zarlcodeModel,
-		codexEffort:         *zarlcodeCodexEffort,
-		llamacppResetURL:    *llamacppResetURL,
-		allowRemoteResetURL: *allowRemoteResetURL,
-		verifiedAttempts:    *zarlcodeVerifiedAttempts,
-		verifyDataset:       *scoreDataset,
-		verifyPython:        *scorePython,
-		verifyWorkers:       *zarlcodeVerifyWorkers,
-		verifyWorkDir:       *zarlcodeVerifyWorkDir,
-		verifyTimeout:       *zarlcodeVerifyTimeout,
-		threadTranscript:    *zarlcodeThreadTranscript,
-		transcriptDir:       *zarlcodeTranscriptDir,
-	})
+	drivers, err := buildDrivers(cfg, ablations)
 	if err != nil {
 		return fmt.Errorf("--drivers: %w", err)
 	}
@@ -160,7 +101,7 @@ func run() error {
 	// after the run.
 	defer closeDrivers(drivers)
 
-	parent := *worktreeDir
+	parent := cfg.Worktrees.Dir
 	if parent == "" {
 		parent = filepath.Join(os.TempDir(), fmt.Sprintf("swebench-eval-%d", time.Now().Unix()))
 	}
@@ -174,49 +115,49 @@ func run() error {
 	// Persist the run + results to ~/.zarlcode/swebench-eval.db so
 	// future comparisons (and the score-update step below) have a
 	// stable home.
-	store, err := db.Open(ctx, *dbPath)
+	store, err := db.Open(ctx, cfg.Persistence.DBPath)
 	if err != nil {
 		return fmt.Errorf("open swebench-eval db: %w", err)
 	}
 	defer store.Close()
 
-	if *runID == "" {
-		*runID = uuid.NewString()
+	if cfg.Persistence.RunID == "" {
+		cfg.Persistence.RunID = uuid.NewString()
 	}
 	startedAt := time.Now()
 	runRec := db.RunRecord{
-		ID:             *runID,
+		ID:             cfg.Persistence.RunID,
 		StartedAt:      startedAt,
-		DatasetName:    *scoreDataset,
-		LanguageFilter: *langFlag,
+		DatasetName:    cfg.Scoring.Dataset,
+		LanguageFilter: cfg.Input.Languages,
 		SampleSize:     len(specs),
-		Drivers:        *driversFlag,
-		TaskTimeoutMs:  taskTimeout.Milliseconds(),
-		Notes:          *runNotes,
+		Drivers:        cfg.Input.Drivers,
+		TaskTimeoutMs:  cfg.Execution.TaskTimeout.Milliseconds(),
+		Notes:          cfg.Persistence.Notes,
 	}
 	if err := store.InsertRun(ctx, runRec); err != nil {
 		return fmt.Errorf("persist run: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "swebench-eval: run_id=%s (sample=%d drivers=%s)\n",
-		*runID, len(specs), *driversFlag)
+		cfg.Persistence.RunID, len(specs), cfg.Input.Drivers)
 
 	// Per-task persistence: each (task, driver) result lands in
 	// eval_results as it finishes, not at end-of-run. Mid-run crash
 	// loses pending tasks but keeps completed ones — recoverable.
-	cfg := runner.Config{
+	runCfg := runner.Config{
 		Drivers:         drivers,
 		Specs:           specs,
 		WorktreeParent:  parent,
-		CloneCache:      *cloneCache,
-		TaskTimeout:     *taskTimeout,
-		TaskConcurrency: *concurrency,
-		KeepWorktrees:   *keepWorktrees,
+		CloneCache:      cfg.Worktrees.CloneCache,
+		TaskTimeout:     cfg.Execution.TaskTimeout,
+		TaskConcurrency: cfg.Execution.Concurrency,
+		KeepWorktrees:   cfg.Worktrees.Keep,
 		OnTaskComplete: func(rec runner.TaskResult) {
-			persistOneResult(ctx, store, *runID, rec)
+			persistOneResult(ctx, store, cfg.Persistence.RunID, rec)
 		},
 	}
 
-	results, err := runner.Run(ctx, cfg)
+	results, err := runner.Run(ctx, runCfg)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
@@ -227,62 +168,33 @@ func run() error {
 	// but the row is idempotent enough — re-inserting the same key
 	// errors out and we log+continue.
 
-	if *score {
+	if cfg.Scoring.Enabled {
 		if scoreErr := runner.Score(ctx, &results, runner.ScoreConfig{
-			DatasetName: *scoreDataset,
-			MaxWorkers:  *scoreWorkers,
-			WorkDir:     *scoreWorkDir,
-			Python:      *scorePython,
+			DatasetName: cfg.Scoring.Dataset,
+			MaxWorkers:  cfg.Scoring.Workers,
+			WorkDir:     cfg.Scoring.WorkDir,
+			Python:      cfg.Scoring.Python,
 		}); scoreErr != nil {
 			fmt.Fprintln(os.Stderr, "score:", scoreErr)
 		} else {
-			persistResolved(ctx, store, *runID, results)
+			persistResolved(ctx, store, cfg.Persistence.RunID, results)
 		}
 	}
 
-	if err := store.FinishRun(ctx, *runID, time.Now()); err != nil {
+	if err := store.FinishRun(ctx, cfg.Persistence.RunID, time.Now()); err != nil {
 		fmt.Fprintln(os.Stderr, "finish run:", err)
 	}
 
 	report.Console(os.Stdout, results)
-	fmt.Fprintf(os.Stdout, "\nrun_id: %s\n", *runID)
+	fmt.Fprintf(os.Stdout, "\nrun_id: %s\n", cfg.Persistence.RunID)
 	return nil
-}
-
-// driverBuildOpts groups the (already-7-field, growing) parameters
-// the driver factories need. Adding a new flag → new field here,
-// flow through buildDrivers, no per-driver constructor surgery.
-type driverBuildOpts struct {
-	spec                string
-	ablations           []harness.Ablation
-	envFile             string
-	stateDB             string
-	maxIter             int
-	toolConcurrency     int
-	contextWindow       int
-	streamIdle          time.Duration
-	iterationTimeout    time.Duration
-	deadlineGrace       time.Duration
-	provider            string
-	model               string
-	codexEffort         string
-	llamacppResetURL    string
-	allowRemoteResetURL bool
-	verifiedAttempts    int
-	verifyDataset       string
-	verifyPython        string
-	verifyWorkers       int
-	verifyWorkDir       string
-	verifyTimeout       time.Duration
-	threadTranscript    bool
-	transcriptDir       string
 }
 
 // buildDrivers parses the --drivers flag and instantiates the named
 // adapters with shared per-driver config. Unknown names are rejected so a
 // typo cannot silently change the evaluation comparison set.
-func buildDrivers(o driverBuildOpts) ([]harness.Driver, error) {
-	names := strings.Split(o.spec, ",")
+func buildDrivers(cfg evalconfig.Config, ablations []harness.Ablation) ([]harness.Driver, error) {
+	names := strings.Split(cfg.Input.Drivers, ",")
 	out := make([]harness.Driver, 0, len(names))
 	for _, raw := range names {
 		name := strings.TrimSpace(raw)
@@ -292,34 +204,34 @@ func buildDrivers(o driverBuildOpts) ([]harness.Driver, error) {
 			// driver). Each arm carries its own provider handle; that's
 			// per-arm overhead on the shared state.db, accepted so an
 			// arm's judge can't share state with another arm's loop.
-			arms := o.ablations
+			arms := ablations
 			if len(arms) == 0 {
 				arms = []harness.Ablation{{}}
 			}
 			for _, arm := range arms {
 				out = append(out, &harness.ZarlcodeDriver{
 					Ablation:            arm,
-					EnvFile:             o.envFile,
-					StateDB:             o.stateDB,
-					MaxIter:             o.maxIter,
-					ToolConcurrency:     o.toolConcurrency,
-					ContextWindow:       o.contextWindow,
-					StreamIdle:          o.streamIdle,
-					IterationTimeout:    o.iterationTimeout,
-					DeadlineGrace:       o.deadlineGrace,
-					Provider:            o.provider,
-					Model:               o.model,
-					CodexEffort:         o.codexEffort,
-					LlamacppResetURL:    o.llamacppResetURL,
-					AllowRemoteResetURL: o.allowRemoteResetURL,
-					VerifiedAttempts:    o.verifiedAttempts,
-					VerifyDataset:       o.verifyDataset,
-					VerifyPython:        o.verifyPython,
-					VerifyWorkers:       o.verifyWorkers,
-					VerifyWorkDir:       o.verifyWorkDir,
-					VerifyTimeout:       o.verifyTimeout,
-					ThreadTranscript:    o.threadTranscript,
-					TranscriptDir:       o.transcriptDir,
+					EnvFile:             cfg.Zarlcode.EnvFile,
+					StateDB:             cfg.Zarlcode.StateDB,
+					MaxIter:             cfg.Zarlcode.MaxIter,
+					ToolConcurrency:     cfg.Zarlcode.ToolConcurrency,
+					ContextWindow:       cfg.Zarlcode.ContextWindow,
+					StreamIdle:          cfg.Zarlcode.StreamIdle,
+					IterationTimeout:    cfg.Zarlcode.IterationTimeout,
+					DeadlineGrace:       cfg.Zarlcode.DeadlineGrace,
+					Provider:            cfg.Zarlcode.Provider,
+					Model:               cfg.Zarlcode.Model,
+					CodexEffort:         cfg.Zarlcode.CodexEffort,
+					LlamacppResetURL:    cfg.Zarlcode.LlamacppResetURL,
+					AllowRemoteResetURL: cfg.Zarlcode.AllowRemoteResetURL,
+					VerifiedAttempts:    cfg.Zarlcode.VerifiedAttempts,
+					VerifyDataset:       cfg.Scoring.Dataset,
+					VerifyPython:        cfg.Scoring.Python,
+					VerifyWorkers:       cfg.Zarlcode.VerifyWorkers,
+					VerifyWorkDir:       cfg.Zarlcode.VerifyWorkDir,
+					VerifyTimeout:       cfg.Zarlcode.VerifyTimeout,
+					ThreadTranscript:    cfg.Zarlcode.ThreadTranscript,
+					TranscriptDir:       cfg.Zarlcode.TranscriptDir,
 				})
 			}
 		default:

--- a/swebench-eval/evalconfig/evalconfig.go
+++ b/swebench-eval/evalconfig/evalconfig.go
@@ -1,0 +1,144 @@
+// Package evalconfig parses command-line configuration for the SWE-bench evaluator.
+package evalconfig
+
+import (
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/zarldev/zarlmono/swebench-eval/harness"
+)
+
+// Config groups the evaluator's command-line settings by responsibility.
+type Config struct {
+	Input       InputConfig
+	Zarlcode    ZarlcodeConfig
+	Execution   ExecutionConfig
+	Worktrees   WorktreeConfig
+	Scoring     ScoringConfig
+	Persistence PersistenceConfig
+	Version     bool
+}
+
+// InputConfig selects tasks and evaluation arms.
+type InputConfig struct {
+	Tasks        string
+	Drivers      string
+	AblationSpec string
+	Languages    string
+	Sample       int
+}
+
+// LanguageFilter returns the configured comma-separated language filter.
+func (c InputConfig) LanguageFilter() []string {
+	if c.Languages == "" {
+		return nil
+	}
+	return strings.Split(c.Languages, ",")
+}
+
+// Ablations resolves the configured ablation names in their requested order.
+func (c InputConfig) Ablations() ([]harness.Ablation, error) {
+	return harness.AblationArms(c.AblationSpec)
+}
+
+// ZarlcodeConfig configures the in-process zarlcode driver.
+type ZarlcodeConfig struct {
+	EnvFile             string
+	Provider            string
+	Model               string
+	CodexEffort         string
+	LlamacppResetURL    string
+	AllowRemoteResetURL bool
+	StateDB             string
+	MaxIter             int
+	ToolConcurrency     int
+	ContextWindow       int
+	StreamIdle          time.Duration
+	IterationTimeout    time.Duration
+	DeadlineGrace       time.Duration
+	VerifiedAttempts    int
+	VerifyWorkers       int
+	VerifyWorkDir       string
+	VerifyTimeout       time.Duration
+	ThreadTranscript    bool
+	TranscriptDir       string
+}
+
+// ExecutionConfig controls harness timing and parallelism.
+type ExecutionConfig struct {
+	TaskTimeout time.Duration
+	Concurrency int
+}
+
+// WorktreeConfig controls task checkout materialization.
+type WorktreeConfig struct {
+	Dir        string
+	CloneCache string
+	Keep       bool
+}
+
+// ScoringConfig controls optional SWE-bench evaluator scoring.
+type ScoringConfig struct {
+	Enabled bool
+	Dataset string
+	Workers int
+	WorkDir string
+	Python  string
+}
+
+// PersistenceConfig controls the evaluation run record.
+type PersistenceConfig struct {
+	DBPath string
+	RunID  string
+	Notes  string
+}
+
+// Parse registers the eval command's flags on fs and parses args.
+func Parse(fs *flag.FlagSet, args []string) (Config, error) {
+	var cfg Config
+
+	fs.StringVar(&cfg.Input.Tasks, "tasks", "", "path to SWE-bench JSONL or Parquet task file (required)")
+	fs.StringVar(&cfg.Input.Drivers, "drivers", "zarlcode", "comma-separated list of drivers to run (zarlcode)")
+	fs.StringVar(&cfg.Input.AblationSpec, "ablations", "", "comma-separated zarlcode guardrail-ablation arms, or \"all\" (baseline, no-shell, no-skill-hint, no-decompose, no-fanout, no-test-edit, no-improvement, judge); each arm runs as its own driver")
+	fs.StringVar(&cfg.Input.Languages, "languages", "", "comma-separated language filter (empty = all)")
+	fs.IntVar(&cfg.Input.Sample, "sample", 0, "stratified sample size (0 = run all matching specs)")
+	fs.StringVar(&cfg.Zarlcode.EnvFile, "env", "", "path to .env loaded before provider construction (carries per-backend URL/key knobs)")
+	fs.StringVar(&cfg.Zarlcode.Provider, "zarlcode-provider", "", "pin zarlcode's backend (registry name: llamacpp, openai-codex, gemini, claude-code, …); empty = registry default (llamacpp)")
+	fs.StringVar(&cfg.Zarlcode.Model, "zarlcode-model", "", "pin zarlcode's model (e.g. gpt-5.5, qwen3.6-35b-a3b-mtp); empty = provider's default model")
+	fs.StringVar(&cfg.Zarlcode.CodexEffort, "zarlcode-codex-effort", "", "codex_reasoning_effort when provider is openai-codex (low/medium/high/xhigh/max)")
+	fs.StringVar(&cfg.Zarlcode.LlamacppResetURL, "llamacpp-reset-url", "", "POSTed before each task to flush local llama-server's KV cache slot; e.g. http://localhost:8081/slots/0?action=erase (requires --slot-save-path on the server)")
+	fs.BoolVar(&cfg.Zarlcode.AllowRemoteResetURL, "allow-remote-reset-url", false, "permit a non-loopback --llamacpp-reset-url (default: loopback only, to avoid SSRF via a misconfigured URL)")
+	fs.StringVar(&cfg.Zarlcode.StateDB, "state-db", "", "path to zarlcode state.db — vault + custom-provider rows (empty = $HOME/.zarlcode/state.db)")
+	fs.DurationVar(&cfg.Execution.TaskTimeout, "task-timeout", 5*time.Minute, "wall-clock budget per (task, driver)")
+	fs.IntVar(&cfg.Zarlcode.MaxIter, "max-iter", 0, "cap the agent loop's iterations (0 = loop default)")
+	fs.IntVar(&cfg.Zarlcode.ToolConcurrency, "tool-concurrency", 0, "cap concurrent tool dispatch per iteration (0 = sequential)")
+	fs.IntVar(&cfg.Zarlcode.ContextWindow, "context-window", 0, "compactor context-window size in tokens (0 = 32768)")
+	fs.DurationVar(&cfg.Zarlcode.StreamIdle, "zarlcode-stream-idle", 0, "zarlcode stream-idle watchdog: gap between chunks before the stall detector fires (0 = coderunner default 90s); raise for slow-prefill local models")
+	fs.DurationVar(&cfg.Zarlcode.IterationTimeout, "zarlcode-iteration-timeout", 0, "zarlcode per-iteration wall-clock backstop (0 = coderunner default 5m); raise for slow-prefill local models")
+	fs.DurationVar(&cfg.Zarlcode.DeadlineGrace, "zarlcode-deadline-grace", 0, "time before the task deadline at which the wrap-up nudge fires (0 = disabled); give the model a last-chance to commit before the task-timeout cancels it")
+	fs.IntVar(&cfg.Zarlcode.VerifiedAttempts, "zarlcode-verified-attempts", 0, "enable zarlcode harness re-drive with SWE-bench verifier; values >1 cap attempts, 0/1 = trust terminal reason")
+	fs.IntVar(&cfg.Zarlcode.VerifyWorkers, "zarlcode-verify-workers", 1, "SWE-bench evaluator workers for per-attempt zarlcode verification")
+	fs.StringVar(&cfg.Zarlcode.VerifyWorkDir, "zarlcode-verify-workdir", "", "directory for per-attempt zarlcode verification logs (empty = tempdir per attempt)")
+	fs.DurationVar(&cfg.Zarlcode.VerifyTimeout, "zarlcode-verify-timeout", 0, "per-attempt SWE-bench verifier timeout, independent of the agent task timeout (0 = 30m)")
+	fs.BoolVar(&cfg.Zarlcode.ThreadTranscript, "zarlcode-thread-transcript", false, "verified re-drives carry the full prior transcript (needs a large --context-window); default re-drives with verifier feedback only")
+	fs.StringVar(&cfg.Zarlcode.TranscriptDir, "zarlcode-transcript-dir", "", "persist each task's full agent transcript to <dir>/<instance_id>.json for post-hoc debugging (empty = disabled)")
+	fs.IntVar(&cfg.Execution.Concurrency, "concurrency", 1, "parallel (task, driver) invocations")
+	fs.StringVar(&cfg.Worktrees.Dir, "worktree-dir", "", "where to materialize worktrees (empty = a fresh tempdir)")
+	fs.StringVar(&cfg.Worktrees.CloneCache, "clone-cache", "", "optional --reference clone cache directory")
+	fs.BoolVar(&cfg.Worktrees.Keep, "keep-worktrees", false, "leave worktrees on disk after the run for post-hoc inspection")
+	fs.BoolVar(&cfg.Scoring.Enabled, "score", false, "after the harness loop, invoke SWE-bench's evaluator on each driver's diffs and report resolved/unresolved")
+	fs.StringVar(&cfg.Scoring.Dataset, "score-dataset", "SWE-bench/SWE-bench_Multilingual", "dataset name passed to the SWE-bench evaluator")
+	fs.IntVar(&cfg.Scoring.Workers, "score-workers", 4, "SWE-bench evaluator --max_workers")
+	fs.StringVar(&cfg.Scoring.WorkDir, "score-workdir", "", "directory for the evaluator's predictions + logs (empty = a fresh tempdir)")
+	fs.StringVar(&cfg.Scoring.Python, "score-python", "", "python interpreter that has the swebench package importable (empty = python3 on PATH; typical: a venv's bin/python)")
+	fs.StringVar(&cfg.Persistence.DBPath, "db", "", "path to swebench-eval sqlite (empty = $HOME/.zarlcode/swebench-eval.db)")
+	fs.StringVar(&cfg.Persistence.RunID, "run-id", "", "explicit run id (empty = a generated uuid)")
+	fs.StringVar(&cfg.Persistence.Notes, "run-notes", "", "free-form notes to attach to the run row — eg. 'after decompose advisory refactor'")
+	fs.BoolVar(&cfg.Version, "version", false, "print the build version and exit")
+
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}

--- a/swebench-eval/evalconfig/evalconfig_test.go
+++ b/swebench-eval/evalconfig/evalconfig_test.go
@@ -1,0 +1,173 @@
+package evalconfig_test
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zarldev/zarlmono/swebench-eval/evalconfig"
+	"github.com/zarldev/zarlmono/swebench-eval/harness"
+)
+
+func parse(t *testing.T, args ...string) (evalconfig.Config, error) {
+	t.Helper()
+	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	return evalconfig.Parse(fs, args)
+}
+
+func TestParseDefaults(t *testing.T) {
+	cfg, err := parse(t)
+	if err != nil {
+		t.Fatalf("Parse defaults: %v", err)
+	}
+	if cfg.Input.Drivers != "zarlcode" || cfg.Execution.TaskTimeout != 5*time.Minute || cfg.Execution.Concurrency != 1 {
+		t.Fatalf("core defaults = drivers %q, timeout %s, concurrency %d", cfg.Input.Drivers, cfg.Execution.TaskTimeout, cfg.Execution.Concurrency)
+	}
+	if cfg.Scoring.Dataset != "SWE-bench/SWE-bench_Multilingual" || cfg.Scoring.Workers != 4 {
+		t.Fatalf("scoring defaults = dataset %q, workers %d", cfg.Scoring.Dataset, cfg.Scoring.Workers)
+	}
+	if cfg.Zarlcode.VerifyWorkers != 1 {
+		t.Fatalf("verify workers default = %d, want 1", cfg.Zarlcode.VerifyWorkers)
+	}
+	if cfg.Input.Tasks != "" || cfg.Input.Sample != 0 || cfg.Version || cfg.Scoring.Enabled {
+		t.Fatalf("zero-value defaults changed: %+v", cfg)
+	}
+}
+
+func TestParseRepresentativeFullArgs(t *testing.T) {
+	args := []string{
+		"--tasks", "tasks.parquet", "--drivers", "zarlcode", "--ablations", "baseline,judge",
+		"--languages", "go,rust", "--sample", "12", "--env", ".env",
+		"--zarlcode-provider", "openai-codex", "--zarlcode-model", "gpt-5.5",
+		"--zarlcode-codex-effort", "xhigh", "--llamacpp-reset-url", "http://localhost:8081/slots/0?action=erase",
+		"--allow-remote-reset-url", "--state-db", "state.db", "--task-timeout", "17m",
+		"--max-iter", "22", "--tool-concurrency", "3", "--context-window", "65536",
+		"--zarlcode-stream-idle", "2m", "--zarlcode-iteration-timeout", "9m",
+		"--zarlcode-deadline-grace", "45s", "--zarlcode-verified-attempts", "4",
+		"--zarlcode-verify-workers", "5", "--zarlcode-verify-workdir", "verify",
+		"--zarlcode-verify-timeout", "31m", "--zarlcode-thread-transcript",
+		"--zarlcode-transcript-dir", "transcripts", "--concurrency", "6",
+		"--worktree-dir", "worktrees", "--clone-cache", "clones", "--keep-worktrees",
+		"--score", "--score-dataset", "dataset", "--score-workers", "7",
+		"--score-workdir", "scores", "--score-python", "python", "--db", "eval.db",
+		"--run-id", "run-1", "--run-notes", "notes", "--version",
+	}
+	cfg, err := parse(t, args...)
+	if err != nil {
+		t.Fatalf("Parse full args: %v", err)
+	}
+
+	want := evalconfig.Config{
+		Input: evalconfig.InputConfig{
+			Tasks: "tasks.parquet", Drivers: "zarlcode", AblationSpec: "baseline,judge",
+			Languages: "go,rust", Sample: 12,
+		},
+		Zarlcode: evalconfig.ZarlcodeConfig{
+			EnvFile: ".env", Provider: "openai-codex", Model: "gpt-5.5", CodexEffort: "xhigh",
+			LlamacppResetURL: "http://localhost:8081/slots/0?action=erase", AllowRemoteResetURL: true,
+			StateDB: "state.db", MaxIter: 22, ToolConcurrency: 3, ContextWindow: 65536,
+			StreamIdle: 2 * time.Minute, IterationTimeout: 9 * time.Minute, DeadlineGrace: 45 * time.Second,
+			VerifiedAttempts: 4, VerifyWorkers: 5, VerifyWorkDir: "verify", VerifyTimeout: 31 * time.Minute,
+			ThreadTranscript: true, TranscriptDir: "transcripts",
+		},
+		Execution:   evalconfig.ExecutionConfig{TaskTimeout: 17 * time.Minute, Concurrency: 6},
+		Worktrees:   evalconfig.WorktreeConfig{Dir: "worktrees", CloneCache: "clones", Keep: true},
+		Scoring:     evalconfig.ScoringConfig{Enabled: true, Dataset: "dataset", Workers: 7, WorkDir: "scores", Python: "python"},
+		Persistence: evalconfig.PersistenceConfig{DBPath: "eval.db", RunID: "run-1", Notes: "notes"},
+		Version:     true,
+	}
+	if !reflect.DeepEqual(cfg, want) {
+		t.Fatalf("Parse full args =\n%+v\nwant:\n%+v", cfg, want)
+	}
+	if !reflect.DeepEqual(cfg.Input.LanguageFilter(), []string{"go", "rust"}) {
+		t.Fatalf("language filter = %v", cfg.Input.LanguageFilter())
+	}
+}
+
+func TestParseRejectsInvalidDurationAndCounts(t *testing.T) {
+	for _, args := range [][]string{
+		{"--task-timeout", "soon"},
+		{"--zarlcode-stream-idle", "later"},
+		{"--sample", "many"},
+		{"--concurrency", "several"},
+		{"--score-workers", "lots"},
+	} {
+		if _, err := parse(t, args...); err == nil {
+			t.Errorf("Parse(%q) succeeded, want flag value error", args)
+		}
+	}
+}
+
+func TestAblationsRejectUnknownAndPreserveOrderAndLabels(t *testing.T) {
+	allCfg, err := parse(t, "--ablations", "all")
+	if err != nil {
+		t.Fatalf("Parse all ablations: %v", err)
+	}
+	allArms, err := allCfg.Input.Ablations()
+	if err != nil {
+		t.Fatalf("All ablations: %v", err)
+	}
+	var allLabels []string
+	for _, arm := range allArms {
+		allLabels = append(allLabels, (&harness.ZarlcodeDriver{Ablation: arm}).Name())
+	}
+	wantAllLabels := []string{
+		"zarlcode", "zarlcode-no-shell", "zarlcode-no-skill-hint", "zarlcode-no-decompose",
+		"zarlcode-no-fanout", "zarlcode-no-test-edit", "zarlcode-no-improvement", "zarlcode-judge",
+	}
+	if !reflect.DeepEqual(allLabels, wantAllLabels) {
+		t.Fatalf("all ablation labels = %v, want %v", allLabels, wantAllLabels)
+	}
+
+	cfg, err := parse(t, "--ablations", "judge,baseline,no-shell")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	arms, err := cfg.Input.Ablations()
+	if err != nil {
+		t.Fatalf("Ablations: %v", err)
+	}
+	var names, labels []string
+	for _, arm := range arms {
+		names = append(names, arm.Name)
+		labels = append(labels, (&harness.ZarlcodeDriver{Ablation: arm}).Name())
+	}
+	if !reflect.DeepEqual(names, []string{"judge", "baseline", "no-shell"}) {
+		t.Fatalf("ablation order = %v", names)
+	}
+	if !reflect.DeepEqual(labels, []string{"zarlcode-judge", "zarlcode", "zarlcode-no-shell"}) {
+		t.Fatalf("driver labels = %v", labels)
+	}
+
+	cfg, err = parse(t, "--ablations", "unknown")
+	if err != nil {
+		t.Fatalf("Parse unknown ablation flag: %v", err)
+	}
+	if _, err := cfg.Input.Ablations(); err == nil || !strings.Contains(err.Error(), "unknown ablation arm") {
+		t.Fatalf("Ablations unknown error = %v", err)
+	}
+}
+
+func TestHelpSnapshot(t *testing.T) {
+	want, err := os.ReadFile("testdata/help.golden")
+	if err != nil {
+		t.Fatalf("read help snapshot: %v", err)
+	}
+	var got bytes.Buffer
+	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
+	fs.SetOutput(&got)
+	_, err = evalconfig.Parse(fs, []string{"-help"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("Parse -help error = %v, want flag.ErrHelp", err)
+	}
+	want = bytes.ReplaceAll(want, []byte(`\t`), []byte("\t"))
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("help output changed\n--- got ---\n%s\n--- want ---\n%s", got.Bytes(), want)
+	}
+}

--- a/swebench-eval/evalconfig/testdata/help.golden
+++ b/swebench-eval/evalconfig/testdata/help.golden
@@ -1,0 +1,77 @@
+Usage of eval:
+  -ablations string
+    \tcomma-separated zarlcode guardrail-ablation arms, or "all" (baseline, no-shell, no-skill-hint, no-decompose, no-fanout, no-test-edit, no-improvement, judge); each arm runs as its own driver
+  -allow-remote-reset-url
+    \tpermit a non-loopback --llamacpp-reset-url (default: loopback only, to avoid SSRF via a misconfigured URL)
+  -clone-cache string
+    \toptional --reference clone cache directory
+  -concurrency int
+    \tparallel (task, driver) invocations (default 1)
+  -context-window int
+    \tcompactor context-window size in tokens (0 = 32768)
+  -db string
+    \tpath to swebench-eval sqlite (empty = $HOME/.zarlcode/swebench-eval.db)
+  -drivers string
+    \tcomma-separated list of drivers to run (zarlcode) (default "zarlcode")
+  -env string
+    \tpath to .env loaded before provider construction (carries per-backend URL/key knobs)
+  -keep-worktrees
+    \tleave worktrees on disk after the run for post-hoc inspection
+  -languages string
+    \tcomma-separated language filter (empty = all)
+  -llamacpp-reset-url string
+    \tPOSTed before each task to flush local llama-server's KV cache slot; e.g. http://localhost:8081/slots/0?action=erase (requires --slot-save-path on the server)
+  -max-iter int
+    \tcap the agent loop's iterations (0 = loop default)
+  -run-id string
+    \texplicit run id (empty = a generated uuid)
+  -run-notes string
+    \tfree-form notes to attach to the run row — eg. 'after decompose advisory refactor'
+  -sample int
+    \tstratified sample size (0 = run all matching specs)
+  -score
+    \tafter the harness loop, invoke SWE-bench's evaluator on each driver's diffs and report resolved/unresolved
+  -score-dataset string
+    \tdataset name passed to the SWE-bench evaluator (default "SWE-bench/SWE-bench_Multilingual")
+  -score-python string
+    \tpython interpreter that has the swebench package importable (empty = python3 on PATH; typical: a venv's bin/python)
+  -score-workdir string
+    \tdirectory for the evaluator's predictions + logs (empty = a fresh tempdir)
+  -score-workers int
+    \tSWE-bench evaluator --max_workers (default 4)
+  -state-db string
+    \tpath to zarlcode state.db — vault + custom-provider rows (empty = $HOME/.zarlcode/state.db)
+  -task-timeout duration
+    \twall-clock budget per (task, driver) (default 5m0s)
+  -tasks string
+    \tpath to SWE-bench JSONL or Parquet task file (required)
+  -tool-concurrency int
+    \tcap concurrent tool dispatch per iteration (0 = sequential)
+  -version
+    \tprint the build version and exit
+  -worktree-dir string
+    \twhere to materialize worktrees (empty = a fresh tempdir)
+  -zarlcode-codex-effort string
+    \tcodex_reasoning_effort when provider is openai-codex (low/medium/high/xhigh/max)
+  -zarlcode-deadline-grace duration
+    \ttime before the task deadline at which the wrap-up nudge fires (0 = disabled); give the model a last-chance to commit before the task-timeout cancels it
+  -zarlcode-iteration-timeout duration
+    \tzarlcode per-iteration wall-clock backstop (0 = coderunner default 5m); raise for slow-prefill local models
+  -zarlcode-model string
+    \tpin zarlcode's model (e.g. gpt-5.5, qwen3.6-35b-a3b-mtp); empty = provider's default model
+  -zarlcode-provider string
+    \tpin zarlcode's backend (registry name: llamacpp, openai-codex, gemini, claude-code, …); empty = registry default (llamacpp)
+  -zarlcode-stream-idle duration
+    \tzarlcode stream-idle watchdog: gap between chunks before the stall detector fires (0 = coderunner default 90s); raise for slow-prefill local models
+  -zarlcode-thread-transcript
+    \tverified re-drives carry the full prior transcript (needs a large --context-window); default re-drives with verifier feedback only
+  -zarlcode-transcript-dir string
+    \tpersist each task's full agent transcript to <dir>/<instance_id>.json for post-hoc debugging (empty = disabled)
+  -zarlcode-verified-attempts int
+    \tenable zarlcode harness re-drive with SWE-bench verifier; values >1 cap attempts, 0/1 = trust terminal reason
+  -zarlcode-verify-timeout duration
+    \tper-attempt SWE-bench verifier timeout, independent of the agent task timeout (0 = 30m)
+  -zarlcode-verify-workdir string
+    \tdirectory for per-attempt zarlcode verification logs (empty = tempdir per attempt)
+  -zarlcode-verify-workers int
+    \tSWE-bench evaluator workers for per-attempt zarlcode verification (default 1)


### PR DESCRIPTION
## Summary
- extract evaluator flag registration and parsing into a public evalconfig package
- group input, zarlcode, execution, worktree, scoring, and persistence settings
- preserve all flag names, defaults, help text, ablation order, and driver labels
- add black-box argument and exact help snapshot coverage

## Verification
- pre/post -help output byte comparison after executable normalization
- go test -C swebench-eval -count=1 ./...
- go tool task check
- go tool task lint
- test-policy gate
- git diff --check