### PR TITLE
chore: automate dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "gomod"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "github.com/anthropics/anthropic-sdk-go"
+      - dependency-name: "github.com/invopop/jsonschema"
+
+  - package-ecosystem: "gomod"
+    directory: "/swebench-eval"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "github.com/anthropics/anthropic-sdk-go"
+      - dependency-name: "github.com/invopop/jsonschema"
+
+  - package-ecosystem: "gomod"
+    directory: "/zarlcode"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "github.com/anthropics/anthropic-sdk-go"
+      - dependency-name: "github.com/invopop/jsonschema"
+
+  - package-ecosystem: "gomod"
+    directory: "/zkit"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "github.com/anthropics/anthropic-sdk-go"
+      - dependency-name: "github.com/invopop/jsonschema"
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ tasks:
     desc: Run the complete module-isolated local pre-release gate
     cmds:
       - go test -count=1 ./tools/releasecheck/... ./tools/genformula/...
+      - task: dependency-pair
       - |
         for m in examples zkit zarlcode swebench-eval; do
           echo "==> isolated dependency check ($m)"
@@ -83,6 +84,12 @@ tasks:
     desc: Reject new same-package tests and Background contexts in tests
     cmds:
       - bash scripts/check-new-test-policy.sh "${TEST_POLICY_BASE:-HEAD}"
+
+  dependency-pair:
+    desc: Verify the validated Anthropic and JSON Schema dependency pair
+    cmds:
+      - bash scripts/check-anthropic-jsonschema-pair.sh
+
   check:
     desc: Build, vet, and test CI-covered Go modules
     cmds:
@@ -90,6 +97,7 @@ tasks:
       - task: vet
       - task: test
       - task: test-policy
+      - task: dependency-pair
 
   lint:
     desc: Run golangci-lint for CI-covered Go modules

--- a/scripts/check-anthropic-jsonschema-pair.sh
+++ b/scripts/check-anthropic-jsonschema-pair.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly anthropic_module=github.com/anthropics/anthropic-sdk-go
+readonly anthropic_version=v1.68.0
+readonly jsonschema_module=github.com/invopop/jsonschema
+readonly jsonschema_version=v0.14.0
+readonly modules=(examples swebench-eval zarlcode zkit)
+
+status=0
+for module in "${modules[@]}"; do
+  anthropic=$(cd "$module" && GOWORK=off go list -mod=readonly -m -f '{{.Version}}' "$anthropic_module")
+  jsonschema=$(cd "$module" && GOWORK=off go list -mod=readonly -m -f '{{.Version}}' "$jsonschema_module")
+
+  if [[ "$anthropic" != "$anthropic_version" || "$jsonschema" != "$jsonschema_version" ]]; then
+    printf '%s: incompatible Anthropic/JSON Schema pair: %s %s, %s %s\n' \
+      "$module" "$anthropic_module" "$anthropic" "$jsonschema_module" "$jsonschema" >&2
+    status=1
+  fi
+done
+
+if ((status == 0)); then
+  printf 'Anthropic/JSON Schema pair verified in: %s\n' "${modules[*]}"
+fi
+
+exit "$status"

--- a/zkit/go.mod
+++ b/zkit/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/chromedp/chromedp v0.16.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/lmittmann/tint v1.2.0
@@ -52,7 +53,6 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.21 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect


### PR DESCRIPTION
## Summary
- add grouped weekly Dependabot updates for all Go modules, the docs site, and GitHub Actions
- keep Anthropic and JSON Schema updates manual as a validated compatible pair
- enforce the current pair in check and release-check tasks
- record go-cmp as a direct zkit test dependency as derived by go mod tidy

## Verification
- go mod tidy in every module
- dependency-pair assertion
- Dependabot YAML parse validation
- npm --prefix site ci && npm --prefix site run build
- go tool task check
- go tool task lint
- go tool task race
- release-check completed through docs build; npm audit was externally stalled and terminated
- git diff --check