### PR TITLE
Restore GPT-6 Astra for OpenAI Codex subscriptions

### DIFF
--- a/zarlcode/engine/text_verbosity_test.go
+++ b/zarlcode/engine/text_verbosity_test.go
@@ -73,6 +73,9 @@ func TestCodexEffortIsValidatedForSelectedModel(t *testing.T) {
 	}
 
 	codex := backends.NameOpenAICodex.String()
+	if got := settings.CodexEffort(t.Context(), engine.ProviderSpec{Name: codex, Model: "gpt-6-astra"}); got != "max" {
+		t.Fatalf("gpt-6-astra effort = %q, want max", got)
+	}
 	if got := settings.CodexEffort(t.Context(), engine.ProviderSpec{Name: codex, Model: "gpt-5.6"}); got != "max" {
 		t.Fatalf("gpt-5.6 effort = %q, want max", got)
 	}

--- a/zkit/ai/llm/backends/registry_test.go
+++ b/zkit/ai/llm/backends/registry_test.go
@@ -320,6 +320,9 @@ func TestFetchModelsOAuthBuiltinsReturnPresets(t *testing.T) {
 			if len(models) == 0 {
 				t.Fatalf("FetchModels(%q) = empty, want preset models", name)
 			}
+			if name == "openai-codex" && !slices.Contains(models, "gpt-6-astra") {
+				t.Fatalf("FetchModels(%q) = %v, want gpt-6-astra for settings and quick model pickers", name, models)
+			}
 			if name == "claude-code" && !slices.Contains(models, "fable") {
 				t.Fatalf("FetchModels(%q) = %v, want fable", name, models)
 			}

--- a/zkit/ai/llm/openaicodex/models.go
+++ b/zkit/ai/llm/openaicodex/models.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	modelGPT6Astra     = "gpt-6-astra"
+	gpt6ContextWindow  = 1_050_000
 	modelGPT56         = "gpt-5.6"
 	modelGPT56Sol      = "gpt-5.6-sol"
 	modelGPT56Terra    = "gpt-5.6-terra"
@@ -52,6 +54,8 @@ type modelPreset struct {
 // are intentionally not listed; they may remain API-key-only, but zarlcode's
 // openai-codex backend uses ChatGPT OAuth.
 var presetModels = []modelPreset{
+	// gpt-6-astra (strongest end-to-end coding, apps, and research model)
+	{ID: modelGPT6Astra, BaseModel: modelGPT6Astra, Description: "GPT-6 Astra (most capable)", ContextWindow: gpt6ContextWindow},
 	// gpt-5.6 alias (OpenAI's recommended Codex CLI shorthand for Sol)
 	{ID: modelGPT56, BaseModel: modelGPT56, Description: "GPT-5.6 (recommended)", ContextWindow: gpt56ContextWindow},
 	// gpt-5.6-sol (strongest coding/research/cybersecurity model)
@@ -112,6 +116,7 @@ func ContextWindowFor(id string) int {
 // by the settings pane (later) to constrain the effort dropdown to
 // what the active model actually accepts.
 var effortVariants = map[string][]reasoningEffort{
+	modelGPT6Astra:  gpt56Efforts(),
 	modelGPT56:      gpt56Efforts(),
 	modelGPT56Sol:   gpt56Efforts(),
 	modelGPT56Terra: gpt56Efforts(),

--- a/zkit/ai/llm/openaicodex/provider_test.go
+++ b/zkit/ai/llm/openaicodex/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -278,6 +279,50 @@ func TestProvider_RequestWireRegressions(t *testing.T) {
 			}
 			tt.check(t, cb.lastBody)
 		})
+	}
+}
+
+func TestProvider_AstraMaxPresetMapsBaseModelAndEffort(t *testing.T) {
+	t.Parallel()
+	cb := newCodexBackend(t, func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, "data: "+`{"type":"response.completed","response":{"usage":{}}}`+"\n\n")
+	})
+	defer cb.Close()
+
+	provider, err := openaicodex.NewProvider(
+		openaicodex.StaticTokenSource{T: freshToken(t, "acct_test")},
+		openaicodex.WithBaseURL(cb.srv.URL),
+		openaicodex.WithNoRetry(),
+		openaicodex.WithModel("gpt-6-astra-max"),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	for _, streamErr := range provider.Complete(t.Context(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hello"}},
+	}) {
+		if streamErr != nil {
+			t.Fatalf("Complete: %v", streamErr)
+		}
+	}
+
+	if got := cb.lastBody["model"]; got != "gpt-6-astra" {
+		t.Fatalf("wire model = %v, want gpt-6-astra", got)
+	}
+	reasoning, ok := cb.lastBody["reasoning"].(map[string]any)
+	if !ok {
+		t.Fatalf("reasoning = %#v, want object", cb.lastBody["reasoning"])
+	}
+	if got := reasoning["effort"]; got != "max" {
+		t.Fatalf("reasoning effort = %v, want max", got)
+	}
+}
+
+func TestGPT6AstraSupportsAllReasoningEfforts(t *testing.T) {
+	t.Parallel()
+	want := []string{"low", "medium", "high", "xhigh", "max"}
+	if got := openaicodex.EffortVariants("gpt-6-astra"); !slices.Equal(got, want) {
+		t.Fatalf("EffortVariants(gpt-6-astra) = %v, want %v", got, want)
 	}
 }
 
@@ -685,10 +730,11 @@ func TestProvider_DoesNotRetryOn4xxOtherThan429(t *testing.T) {
 func TestListPresetModelsContainsExpectedIDs(t *testing.T) {
 	t.Parallel()
 	models := openaicodex.ListPresetModels()
-	if len(models) < 8 {
-		t.Errorf("expected >= 8 preset models, got %d", len(models))
+	if len(models) < 9 {
+		t.Errorf("expected >= 9 preset models, got %d", len(models))
 	}
 	wantIDs := map[string]bool{
+		"gpt-6-astra":         false,
 		"gpt-5.6":             false,
 		"gpt-5.6-sol":         false,
 		"gpt-5.6-terra":       false,
@@ -777,6 +823,28 @@ func TestPresetContextWindowIsConservativeForOAuthBackend(t *testing.T) {
 			t.Errorf("ContextWindowFor(%q) = %d, want %d", model, got, openaicodex.DefaultContextWindow)
 		}
 	}
+}
+
+func TestGPT6AstraPresetContextWindow(t *testing.T) {
+	t.Parallel()
+	const wantContextWindow = 1_050_000
+
+	for _, id := range []string{"gpt-6-astra", "gpt-6-astra-max"} {
+		if got := openaicodex.ContextWindowFor(id); got != wantContextWindow {
+			t.Errorf("ContextWindowFor(%q) = %d, want %d", id, got, wantContextWindow)
+		}
+	}
+
+	for _, model := range openaicodex.ListPresetModels() {
+		if model.ID != "gpt-6-astra" {
+			continue
+		}
+		if model.MaxTokens != wantContextWindow {
+			t.Fatalf("gpt-6-astra MaxTokens = %d, want %d", model.MaxTokens, wantContextWindow)
+		}
+		return
+	}
+	t.Fatal("gpt-6-astra missing from ListPresetModels")
 }
 
 func TestProvider_NonStreamingCallerStillRequestsSSE(t *testing.T) {


### PR DESCRIPTION
## Summary

- restore the transcript-confirmed `gpt-6-astra` static preset accidentally omitted from commit `70085d4`
- expose its 1,050,000-token context and low/medium/high/xhigh/max reasoning efforts
- map `gpt-6-astra-max` to wire model `gpt-6-astra` with `max` effort
- verify the OAuth backend catalogue consumed by Settings and the Ctrl+E quick model picker includes Astra
- validate persisted Codex `max` effort for Astra in zarlcode settings

The previously completed API-key Astra support, long-context pricing tier, Responses routing, capabilities, text verbosity, and Codex generation POST retry behavior are already present on `main` and remain unchanged.

## Verification

- `go test -C zkit -count=1 ./ai/llm/openaicodex ./ai/llm/backends`
- `go test -C zarlcode -count=1 ./engine ./tui`
- `go test -C zkit -race -count=1 ./ai/llm/openaicodex ./ai/llm/backends`
- `go test -C zarlcode -race -count=1 ./engine ./tui`
- `go tool task check`
- `go tool task lint`
- `go tool task race`
- `git diff --check`